### PR TITLE
Add support for Renode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
 build/
 radio-firmware.simplelink
+radio-firmware.cc2538dk
 /Debug/

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
-TARGET = simplelink
-BOARD = launchpad/cc1312r1
+ifeq ($(RENODE),1)
+  TARGET = cc2538dk
+  CFLAGS += -DRENODE
+else
+  TARGET = simplelink
+  BOARD = launchpad/cc1312r1
+endif
+
 CFLAGS += -g
 
 CONTIKI_PROJECT = radio-firmware
 all: $(CONTIKI_PROJECT)
 
-PROJECT_SOURCEFILES += uart1-arch.c
+ifneq ($(RENODE),1)
+  PROJECT_SOURCEFILES += uart1-arch.c
+endif
 
 CONTIKI = ./contiki-ng
 include $(CONTIKI)/Makefile.include

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ the Turpial board, mainly the CC1312R.
   - [Install ARM compiler.](#install-arm-compiler)
   - [Install Uniflash.](#install-uniflash)
   - [Compiling the project.](#compiling-the-project)
+  - [Testing with Renode.](#testing-with-renode)
 
 [License.](#license)
 
@@ -121,11 +122,41 @@ firmware. The built firmware is located under the `build/simplelink/`
 directory.
 
 ```bash
-make TARGET=simplelink BOARD=launchpad/cc1312r
+make
 ```
 
-[arm-gcc]: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads 
+[arm-gcc]: https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads
 [uniflash]: https://www.ti.com/tool/UNIFLASH
+
+### Testing with Renode.
+
+Currently we can test the code without using the actual SimpleLink radio MCU,
+for this case we use Renode as our emulation environment. This allows us to
+develop and test with more flexibility.
+
+ - **Installing Renode**: You can follow the Renode installation guide in their
+[homepage][renode], it can be installed on Linux, Windows and Mac OS.
+
+[renode]: https://renode.io/#downloads
+
+Now you need to build the firmware enabling Renode support:
+
+```bash
+make RENODE=1
+```
+
+To run Renode, from the command line execute this:
+
+```
+renode radio-nodes.resc
+```
+
+You can modify the radio-nodes.resc file to add your own nodes, modify their
+position in relation to each other. Learn more about Renode scripts
+[here][scripts].
+
+[scripts]: https://renode.readthedocs.io/en/latest/introduction/using.html#basic-interactive-workflow
+
 
 ## License.
 

--- a/radio-firmware.c
+++ b/radio-firmware.c
@@ -1,7 +1,7 @@
 /**
  * @file radio-firmware.c
  * @author Locha Mesh project developers (locha.io)
- * @brief 
+ * @brief
  * @version 0.1
  * @date 2019-12-08
  * 
@@ -10,10 +10,12 @@
  */
 
 #include "contiki.h"
+
+#ifndef RENODE
 #include "uart1-arch.h"
 #include "CC1312R1_LAUNCHXL.h"
-
 #include <ti/drivers/UART.h>
+#endif
 
 #include <stdio.h>
 #include <string.h>
@@ -27,23 +29,21 @@ PROCESS_THREAD(uart_process, ev, data)
 
   PROCESS_BEGIN();
 
+#ifndef RENODE
   uart1_init();
+#endif
 
   /* Setup a periodic timer that expires after 10 seconds. */
   etimer_set(&timer, CLOCK_SECOND * 10);
 
-  int tx = CC1312R1_LAUNCHXL_UART1_TX;
-  int rx = CC1312R1_LAUNCHXL_UART1_RX;
-
-  printf("RX: %d\n", rx);
-  printf("TX: %d\n", tx);
-
   while(1) {
+#ifndef RENODE
     int_fast32_t rc = uart1_write("Hello world\n", strlen("Hello world\n"));
     if (rc == UART_ERROR) {
         printf("Failed!");
         break;
     }
+#endif
 
     /* Wait for the periodic timer to expire and then restart the timer. */
     PROCESS_WAIT_EVENT_UNTIL(etimer_expired(&timer));

--- a/radio-firmware.resc
+++ b/radio-firmware.resc
@@ -1,0 +1,28 @@
+mach create $name
+using sysbus
+machine LoadPlatformDescription @platforms/cpus/cc2538.repl
+connector Connect sysbus.radio wireless
+
+machine PyDevFromFile @scripts/pydev/rolling-bit.py 0x400D2004 0x4 True "sysctrl"
+
+$id = `next_value 1`
+
+macro reset
+"""
+    #set node address. 0x00 0x12 0x4B is TI OUI
+    sysbus WriteByte 0x00280028 $id
+    sysbus WriteByte 0x0028002C 0x00
+    sysbus WriteByte 0x00280030 0xAB
+    sysbus WriteByte 0x00280034 0x89
+    sysbus WriteByte 0x00280038 0x00
+    sysbus WriteByte 0x0028003C 0x4B
+    sysbus WriteByte 0x00280040 0x12
+    sysbus WriteByte 0x00280044 0x00
+
+    sysbus LoadBinary @http://antmicro.com/projects/renode/cc2538_rom_dump.bin-s_524288-0c196cdc21b5397f82e0ff42b206d1cc4b6d7522 0x0
+    sysbus LoadELF $bin
+
+    cpu VectorTableOffset `sysbus GetSymbolAddress "vectors"`
+"""
+
+runMacro $reset

--- a/radio-nodes.resc
+++ b/radio-nodes.resc
@@ -1,0 +1,24 @@
+path add $CWD
+emulation CreateWirelessMedium "wireless"
+
+# The radio is using a range-based medium (with the `Range` set to `11`)
+# If not set, the default SimpleMediumFunction will be used (where range is not relevant)
+wireless SetRangeWirelessFunction 11
+
+######################### Machine 0 - begin #########################
+$name="anode"
+$bin=@radio-firmware.cc2538dk
+i $ORIGIN/radio-firmware.resc
+wireless SetPosition radio 0 0 0
+showAnalyzer sysbus.uart0
+mach clear
+########################## Machine 0 - end ##########################
+
+######################### Machine 1 - begin #########################
+$name="cathode"
+$bin=@radio-firmware.cc2538dk
+i $ORIGIN/radio-firmware.resc
+wireless SetPosition radio 10 0 0
+showAnalyzer sysbus.uart0
+mach clear
+########################## Machine 1 - end ##########################


### PR DESCRIPTION
To build for Renode we use the cc2538dk build target (TARGET), because
it's the only one supported by Contiki-NG.

To compile run:

    make RENODE=1

Setting RENODE=0 or not defining it defaults to a normal SimpleLink
CC1312R build.

Renode by default can't use the uart1 API, this limitation can't be
solved yet, a workaround needs to be made but now it's fine.

Signed-off-by: Jean Pierre Dudey <jeandudey@hotmail.com>