### PR TITLE
boards: add "turpial" board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 APPLICATION = radio-firmware
 
 # If no BOARD is found in the environment, use this default:
-BOARD ?= cc1312-launchpad
+BOARD ?= turpial
+ifeq ($(BOARD),turpial)
+  BOARDSDIR ?= $(CURDIR)/boards
+endif
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/RIOT

--- a/boards/turpial/Makefile
+++ b/boards/turpial/Makefile
@@ -1,0 +1,10 @@
+MODULE = board
+
+# Mimic the launchpad board configuration.
+MIMIC_LAUNCHPAD ?= 1
+CFLAGS += -DMIMIC_LAUNCHPAD=$(MIMIC_LAUNCHPAD)
+
+ADDITIONAL_UART ?= 1
+CFLAGS += -DADDITIONAL_UART=$(ADDITIONAL_UART)
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/turpial/Makefile.dep
+++ b/boards/turpial/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
+  USEMODULE += netif
+  USEMODULE += cc26x2_cc13x2_rf
+  USEMODULE += netdev_ieee802154
+endif

--- a/boards/turpial/Makefile.features
+++ b/boards/turpial/Makefile.features
@@ -1,0 +1,8 @@
+CPU = cc26x2_cc13x2
+CPU_MODEL = cc1312r1f3
+
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio_irq
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart

--- a/boards/turpial/Makefile.include
+++ b/boards/turpial/Makefile.include
@@ -1,0 +1,11 @@
+XDEBUGGER = XDS110
+
+# set default port depending on operating system
+PORT_LINUX  ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# configure the flash tool
+include $(RIOTBOARD)/common/cc26x2_cc13x2/Makefile.include

--- a/boards/turpial/board.c
+++ b/boards/turpial/board.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_turpial
+ * @{
+ *
+ * @file
+ * @brief           Board specific implementations for Locha Mesh Turpial
+ *
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+/**
+ * @brief           Initialise the board.
+ */
+
+void board_init(void)
+{
+    cpu_init();
+
+    if (MIMIC_LAUNCHPAD) {
+        gpio_init(LED0_PIN, GPIO_OUT);
+        gpio_init(LED1_PIN, GPIO_OUT);
+    }
+}

--- a/boards/turpial/dist/cc1312r1f3_XDS110.ccxml
+++ b/boards/turpial/dist/cc1312r1f3_XDS110.ccxml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<configurations XML_version="1.2" id="configurations_0">
+    <configuration XML_version="1.2" id="configuration_0">
+        <instance XML_version="1.2" desc="Texas Instruments XDS110 USB Debug Probe" href="connections/TIXDS110_Connection.xml" id="Texas Instruments XDS110 USB Debug Probe" xml="TIXDS110_Connection.xml" xmlpath="connections"/>
+        <connection XML_version="1.2" id="Texas Instruments XDS110 USB Debug Probe">
+            <instance XML_version="1.2" href="drivers/tixds510icepick_c.xml" id="drivers" xml="tixds510icepick_c.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cs_dap.xml" id="drivers" xml="tixds510cs_dap.xml" xmlpath="drivers"/>
+            <instance XML_version="1.2" href="drivers/tixds510cortexM.xml" id="drivers" xml="tixds510cortexM.xml" xmlpath="drivers"/>
+            <property Type="choicelist" Value="1" id="Power Selection">
+                <choice Name="Probe supplied power" value="1">
+                    <property Type="stringfield" Value="3.3" id="Voltage Level"/>
+                </choice>
+            </property>
+            <property Type="choicelist" Value="0" id="JTAG Signal Isolation"/>
+            <property Type="choicelist" Value="4" id="SWD Mode Settings">
+                <choice Name="cJTAG (1149.7) 2-pin advanced modes" value="enable">
+                    <property Type="choicelist" Value="1" id="XDS110 Aux Port"/>
+                </choice>
+            </property>
+            <platform XML_version="1.2" id="platform_0">
+                <instance XML_version="1.2" desc="CC1312R1F3" href="devices/cc1312r1f3.xml" id="CC1312R1F3" xml="cc1312r1f3.xml" xmlpath="devices"/>
+            </platform>
+        </connection>
+    </configuration>
+</configurations>

--- a/boards/turpial/dist/cc1312r1f3_XDS110.dat
+++ b/boards/turpial/dist/cc1312r1f3_XDS110.dat
@@ -1,0 +1,42 @@
+# config version=3.5
+$ sepk
+  pod_drvr=libjioxds110.so
+  pod_port=0
+  pod_supply=1
+  pod_voltage_selection=1
+  pod_voltage=3.3
+  pod_power_isolate=0
+$ /
+$ product
+  title="Texas Instruments XDS110 USB"
+  alias=TI_XDS110_USB
+  name=XDS110
+$ /
+$ uscif
+  tdoedge=FALL
+  tclk_program=DEFAULT
+  tclk_frequency=5.5MHz
+  jtag_isolate=disable
+$ /
+$ dot7
+  dts_usage=enable
+  dts_type=xds110
+  dts_program=emulator
+  dts_frequency=1.0MHz
+  ts_format=oscan2
+  ts_pin_width=only_two
+$ /
+$ swd
+  swd_debug=disabled
+  swo_data=tdo_pin
+$ /
+@ icepick_c family=icepick_c irbits=6 drbits=1 subpaths=2 systemresetsupported=1
+  & subpath_2 address=0 default=no custom=yes force=yes pseudo=no cancelreset=0x1
+    @ bypass_0 family=bypass irbits=4 drbits=1
+  & subpath_0 address=16 default=no custom=yes force=yes pseudo=no cancelreset=0x1
+    @ cs_dap_0 family=cs_dap irbits=4 drbits=1 subpaths=1 identify=0x4BA00477 revision=Legacy systemresetwhileconnected=1
+      & subpath_1 type=debug address=0 default=no custom=yes force=yes pseudo=no
+        @ cortex_m4_0 family=cortex_mxx irbits=0 drbits=0 identify=0x02000000 traceid=0x0
+      & /
+  & /
+# /

--- a/boards/turpial/dist/cc1312r1f3_gdb.conf
+++ b/boards/turpial/dist/cc1312r1f3_gdb.conf
@@ -1,0 +1,1 @@
+target extended-remote :3333

--- a/boards/turpial/doc.txt
+++ b/boards/turpial/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup        boards_turpial Locha Mesh Turpial
+ * @ingroup         boards
+ * @brief           Turpial CC1312R Wireless MCU LaunchPad
+ * */

--- a/boards/turpial/include/board.h
+++ b/boards/turpial/include/board.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup         boards_turpial
+ * @{
+ *
+ * @file
+ * @brief           Board specific definitions for Locha Mesh Turpial
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (25)
+#define XTIMER_ISR_BACKOFF  (20)
+/** @} */
+
+#if MIMIC_LAUNCHPAD == 1
+/**
+ * @name    On-board button configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 13)
+#define BTN0_MODE           GPIO_IN_PU
+
+#define BTN1_PIN            GPIO_PIN(0, 14)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @brief   On-board LED configuration and controlling
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 6)          /**< red   */
+#define LED1_PIN            GPIO_PIN(0, 7)          /**< green */
+
+#define LED0_ON             gpio_set(LED0_PIN)
+#define LED0_OFF            gpio_clear(LED0_PIN)
+#define LED0_TOGGLE         gpio_toggle(LED0_PIN)
+
+#define LED1_ON             gpio_set(LED1_PIN)
+#define LED1_OFF            gpio_clear(LED1_PIN)
+#define LED1_TOGGLE         gpio_toggle(LED1_PIN)
+/** @} */
+#endif /* MIMIC_LAUNCHPAD */
+
+/**
+ * @brief   Initialize board specific hardware
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/turpial/include/periph_conf.h
+++ b/boards/turpial/include/periph_conf.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         boards_turpial
+ * @{
+ *
+ * @file
+ * @brief           Peripheral MCU configuration for Locha Mesh Turpial
+ *
+ * @author          Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @name    Clock configuration
+* @{
+*/
+/* the main clock is fixed to 48MHZ */
+#define CLOCK_CORECLOCK     (48000000U)
+/** @} */
+
+/**
+* @name    Timer configuration
+*
+* General purpose timers (GPT[0-3]) are configured consecutively and in order
+* (without gaps) starting from GPT0, i.e. if multiple timers are enabled.
+*
+* @{
+*/
+static const timer_conf_t timer_config[] = {
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ },
+ {
+     .cfg = GPT_CFG_16T,
+     .chn = 2,
+ },
+ {
+     .cfg = GPT_CFG_32T,
+     .chn = 1,
+ }
+};
+
+#define TIMER_NUMOF         ARRAY_SIZE(timer_config)
+/** @} */
+
+/**
+ * @name    UART configuration
+ *
+ * The used LAUNCHXL-CC1312R board has available a single UART device throught
+ * the debugger, so all we need to configure are the RX and TX pins.
+ *
+ * Optionally we can enable hardware flow control, by setting UART_HW_FLOW_CTRL
+ * to 1 and defining pins for cts_pin and rts_pin.
+ *
+ * Add a second UART configuration if using external pins.
+ * @{
+ */
+
+static const uart_conf_t uart_config[] = {
+ {
+     .regs = UART0,
+     .tx_pin = 3,
+     .rx_pin = 2,
+#ifdef MODULE_PERIPH_UART_HW_FC
+     .rts_pin = 18,
+     .cts_pin = 19,
+#endif
+     .intn = UART0_IRQN
+ },
+#if ADDITIONAL_UART == 1
+ {
+     .regs = UART1,
+     .tx_pin = 3,
+     .rx_pin = 2,
+#ifdef MODULE_PERIPH_UART_HW_FC
+     .rts_pin = 0,
+     .cts_pin = 0,
+#endif
+     .intn = UART1_IRQN
+ }
+#endif /* ADDITIONAL_UART */
+};
+#define UART_NUMOF          ARRAY_SIZE(uart_config)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */


### PR DESCRIPTION
- Adds definition for UART1 if `ADDITIONAL_UART` is set to 1 (default).
- Compatible with cc1312-launchpad by setting `MIMIC_LAUNCHPAD` to 1 (default).

### Known problems

`oonf_api` doesn't compile due to an error in `USEPKG` dependencies, I will add `oonf_api` as a submodule to avoid this problem.