### PR TITLE
manet: fix MANET UDP ports

### DIFF
--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -38,15 +38,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   RFC5444 protocol port number
- * @{
- */
-#ifndef CONFIG_AODVV2_RFC5444_PROTOCOL_PORT
-#define CONFIG_AODVV2_RFC5444_PROTOCOL_PORT (UDP_MANET_PROTOCOLS_1)
-#endif
-/** @} */
-
-/**
  * @name    RFC5444 thread stack size
  * @{
  */

--- a/sys/include/net/manet/manet.h
+++ b/sys/include/net/manet/manet.h
@@ -40,22 +40,22 @@ extern "C" {
                                                   0x00, 0x00, 0x00, 0x6d }}
 
 /**
- * @brief   UDP Port for MANET Protocols 1 (udp/269).
+ * @brief   UDP Port for MANET Protocols (udp/269).
  *
  * @see <a href="https://tools.ietf.org/html/rfc5498#section-6">
  *          RFC 5498, section 6
  *      </a>
  */
-#define UDP_MANET_PROTOCOLS_1 (269)
+#define UDP_MANET_PORT (269)
 
 /**
- * @brief   UDP Port for MANET Protocols 2 (udp/138).
+ * @brief   IP Port for MANET Protocols (138).
  *
  * @see <a href="https://tools.ietf.org/html/rfc5498#section-6">
  *          RFC 5498, section 6
  *      </a>
  */
-#define UDP_MANET_PROTOCOLS_2 (138)
+#define IP_MANET_PROTOCOLS (138)
 
 /**
  * @see @ref IPV6_ADDR_ALL_MANET_ROUTERS_LINK_LOCAL

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -162,7 +162,7 @@ static void _send_packet(struct rfc5444_writer *writer,
     }
 
     /* Build UDP packet */
-    uint16_t port = CONFIG_AODVV2_RFC5444_PROTOCOL_PORT;
+    uint16_t port = UDP_MANET_PORT;
     udp = gnrc_udp_hdr_build(payload, port, port);
     if (udp == NULL) {
         DEBUG("aodvv2: unable to allocate UDP header\n");
@@ -333,8 +333,7 @@ int aodvv2_init(gnrc_netif_t *netif)
                       CONFIG_AODVV2_DEFAULT_METRIC);
 
     /* Register netreg */
-    gnrc_netreg_entry_init_pid(&netreg, CONFIG_AODVV2_RFC5444_PROTOCOL_PORT,
-                               _pid);
+    gnrc_netreg_entry_init_pid(&netreg, UDP_MANET_PORT, _pid);
     gnrc_netreg_register(GNRC_NETTYPE_UDP, &netreg);
 
     /* Initialize RFC5444 reader */


### PR DESCRIPTION
The 138 port is specified for "IP" as the RFC 5498 says and the only UDP
port is the udp/269.

The configuration option for the used port was removed.