### PR TITLE
 aodvv2: find routes reactively

### DIFF
--- a/sys/include/net/aodvv2/aodvv2.h
+++ b/sys/include/net/aodvv2/aodvv2.h
@@ -117,11 +117,14 @@ int aodvv2_send_rrep(aodvv2_packet_data_t *pkt,
 /**
  * @brief   Initiate a route discovery process to find the given address.
  *
+ * @pre @p target_addr != NULL && @p orig_addr != NULL
+ *
  * @param[in] target_addr The IP address where we want a route to.
  *
  * @return Negative number on failure, otherwise succeed.
  */
-int aodvv2_find_route(ipv6_addr_t *target_addr);
+int aodvv2_find_route(const ipv6_addr_t *orig_addr,
+                      const ipv6_addr_t *target_addr);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sys/include/net/aodvv2/aodvv2.h
+++ b/sys/include/net/aodvv2/aodvv2.h
@@ -126,6 +126,30 @@ int aodvv2_send_rrep(aodvv2_packet_data_t *pkt,
 int aodvv2_find_route(const ipv6_addr_t *orig_addr,
                       const ipv6_addr_t *target_addr);
 
+/**
+ * @brief   Initialize the AODVv2 packer buffering code.
+ */
+void aodvv2_buffer_init(void);
+
+/**
+ * @brief   Add a packet to the packet buffer
+ *
+ * @pre @p dst != NULL && @p pkt != NULL
+ *
+ * @brief[in] dst Packet destination address.
+ * @brief[in] pkt Packet.
+ */
+int aodvv2_buffer_pkt_add(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt);
+
+/**
+ * @brief   Dispatch buffered packets to `targ_addr`
+ *
+ * @notes Only call this when a route to `targ_addr` is on the NIB
+ *
+ * @param[in] targ_addr Target address to dispatch packets.
+ */
+void aodvv2_buffer_dispatch(const ipv6_addr_t *targ_addr);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -169,7 +169,7 @@ void aodvv2_rfc5444_writer_register(struct rfc5444_writer *writer,
  * @param[in] src  Source.
  * @param[out] dst Destination.
  */
-void ipv6_addr_to_netaddr(ipv6_addr_t *src, struct netaddr *dst);
+void ipv6_addr_to_netaddr(const ipv6_addr_t *src, struct netaddr *dst);
 
 /**
  * @brief   `struct netaddr` to `ipv6_addr_t`.

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -449,8 +449,11 @@ int aodvv2_send_rrep(aodvv2_packet_data_t *pkt,
     return 0;
 }
 
-int aodvv2_find_route(ipv6_addr_t *target_addr)
+int aodvv2_find_route(const ipv6_addr_t *orig_addr,
+                      const ipv6_addr_t *target_addr)
 {
+    assert(orig_addr != NULL && target_addr != NULL);
+
     aodvv2_packet_data_t pkt;
 
     /* Set metric information */
@@ -458,13 +461,7 @@ int aodvv2_find_route(ipv6_addr_t *target_addr)
     pkt.metric_type = CONFIG_AODVV2_DEFAULT_METRIC;
 
     /* Set OrigNode information */
-    ipv6_addr_t orig_addr;
-    if (_find_netif_global_addr(&orig_addr) < 0) {
-        DEBUG("aodvv2: no global address found\n");
-        return -1;
-    }
-
-    ipv6_addr_to_netaddr(&orig_addr, &pkt.orig_node.addr);
+    ipv6_addr_to_netaddr(orig_addr, &pkt.orig_node.addr);
     pkt.orig_node.metric = 0;
     pkt.orig_node.seqnum = aodvv2_seqnum_get();
     aodvv2_seqnum_inc();

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -34,7 +34,7 @@
 
 #include "mutex.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 #if ENABLE_DEBUG == 1

--- a/sys/net/aodvv2/aodvv2_buffer.c
+++ b/sys/net/aodvv2/aodvv2_buffer.c
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_aodvv2
+ * @{
+ *
+ * @file
+ * @brief       AODVv2 packet buffering
+ *
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ * @}
+ */
+
+#include <stdbool.h>
+
+#include "net/aodvv2/aodvv2.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/ipv6.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define CONFIG_AODVV2_MAX_BUFFERED_PACKETS (10)
+
+typedef struct {
+    bool used;
+    gnrc_pktsnip_t *pkt;
+    ipv6_addr_t dst;
+} buffered_pkt_t;
+
+static buffered_pkt_t _buffered_pkts[CONFIG_AODVV2_MAX_BUFFERED_PACKETS];
+
+static void _pkt_del(unsigned i)
+{
+    buffered_pkt_t *entry = &_buffered_pkts[i];
+    if (entry->used) {
+        entry->used = false;
+        gnrc_pktbuf_release(entry->pkt);
+        entry->pkt = NULL;
+        entry->dst = ipv6_addr_unspecified;
+    }
+}
+
+void aodvv2_buffer_init(void)
+{
+    memset(_buffered_pkts, 0, sizeof(_buffered_pkts));
+}
+
+int aodvv2_buffer_pkt_add(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt)
+{
+    for (unsigned i = 0; i < ARRAY_SIZE(_buffered_pkts); i++) {
+        buffered_pkt_t *entry = &_buffered_pkts[i];
+        /* Find free spot */
+        if (!entry->used) {
+            entry->used = true;
+            entry->pkt = pkt;
+            memcpy(&entry->dst, dst, sizeof(ipv6_addr_t));
+
+            /* Increase reference count for this packet as we'll l store it
+             * until we find a route to send it (or not, and release the
+             * packet) */
+            gnrc_pktbuf_hold(entry->pkt, 1);
+
+            return 0;
+        }
+    }
+
+    /* List of buffered packets is _full_ :/ */
+    return -1;
+}
+
+void aodvv2_buffer_dispatch(const ipv6_addr_t *targ_addr)
+{
+    assert(targ_addr != NULL);
+
+    for (unsigned i = 0; i < ARRAY_SIZE(_buffered_pkts); i++) {
+        buffered_pkt_t *entry = &_buffered_pkts[i];
+
+        if (ipv6_addr_equal(&entry->dst, targ_addr)) {
+            int res = gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6,
+                                                GNRC_NETREG_DEMUX_CTX_ALL,
+                                                entry->pkt);
+
+            if (res < 1) {
+                DEBUG("aodvv2: couldn't dispatch packet!\n");
+            }
+            _pkt_del(i);
+        }
+    }
+}
+

--- a/sys/net/aodvv2/aodvv2_client.c
+++ b/sys/net/aodvv2/aodvv2_client.c
@@ -105,9 +105,11 @@ aodvv2_client_entry_t *aodvv2_client_find(const ipv6_addr_t *addr)
 
     mutex_lock(&_set_mutex);
     for (unsigned i = 0; i < ARRAY_SIZE(_client_set); i++) {
-        if (ipv6_addr_equal(&_client_set[i].ip_address, addr)) {
-            mutex_unlock(&_set_mutex);
-            return &_client_set[i];
+        if (_client_set[i]._used) {
+            if (ipv6_addr_equal(&_client_set[i].ip_address, addr)) {
+                mutex_unlock(&_set_mutex);
+                return &_client_set[i];
+            }
         }
     }
     mutex_unlock(&_set_mutex);

--- a/sys/net/aodvv2/aodvv2_client.c
+++ b/sys/net/aodvv2/aodvv2_client.c
@@ -25,7 +25,7 @@
 
 #include "mutex.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 static aodvv2_client_entry_t _client_set[CONFIG_AODVV2_CLIENT_SET_ENTRIES];

--- a/sys/net/aodvv2/aodvv2_routingtable.c
+++ b/sys/net/aodvv2/aodvv2_routingtable.c
@@ -22,7 +22,7 @@
 #include "net/aodvv2/aodvv2.h"
 #include "net/aodvv2/routingtable.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 static void _reset_entry_if_stale(uint8_t i);

--- a/sys/net/aodvv2/aodvv2_rreqtable.c
+++ b/sys/net/aodvv2/aodvv2_rreqtable.c
@@ -24,7 +24,7 @@
 #include "net/aodvv2/aodvv2.h"
 #include "net/aodvv2/rreqtable.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 static aodvv2_rreq_entry_t *_get_comparable_rreq(aodvv2_packet_data_t *packet_data);

--- a/sys/net/aodvv2/rfc5444_compat.c
+++ b/sys/net/aodvv2/rfc5444_compat.c
@@ -26,7 +26,7 @@
 
 #include <assert.h>
 
-void ipv6_addr_to_netaddr(ipv6_addr_t *src, struct netaddr *dst)
+void ipv6_addr_to_netaddr(const ipv6_addr_t *src, struct netaddr *dst)
 {
     assert(src != NULL && dst != NULL);
 

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -33,7 +33,7 @@
 
 #include "xtimer.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 #define AODVV2_ROUTE_LIFETIME \

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -298,6 +298,12 @@ static enum rfc5444_result _cb_rrep_end_callback(
               packet_data.orig_node.seqnum);
         DEBUG("rfc5444_reader: We are done here, thanks %s!\n",
               netaddr_to_string(&nbuf, &packet_data.targ_node.addr));
+
+        ipv6_addr_t targ_addr;
+        netaddr_to_ipv6_addr(&packet_data.targ_node.addr, &targ_addr);
+
+        /* Send buffered packets for this address */
+        aodvv2_buffer_dispatch(&targ_addr);
     }
     else {
         /* If HandlingRtr is not RREQ_Gen then the outgoing RREP is sent to the

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -24,7 +24,7 @@
 #include "net/aodvv2/rfc5444.h"
 #include "net/aodvv2/metric.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 static void _cb_add_message_header(struct rfc5444_writer *wr,

--- a/sys/shell_extended/find_route.c
+++ b/sys/shell_extended/find_route.c
@@ -30,8 +30,8 @@ int find_route_cmd(int argc, char **argv)
 {
     int res = 0;
 
-    if (argc < 2) {
-        puts("find_route <target>");
+    if (argc < 3) {
+        puts("find_route <target> <orig>");
         puts("find a route using AODVv2 protocol to <target>");
         goto exit;
     }
@@ -44,7 +44,14 @@ int find_route_cmd(int argc, char **argv)
         goto exit;
     }
 
-    res = aodvv2_find_route(&target_addr);
+    ipv6_addr_t orig_addr;
+    if (ipv6_addr_from_str(&orig_addr, argv[2]) == NULL) {
+        res = -1;
+        printf("%s: invalid <orig>!\n", argv[0]);
+        goto exit;
+    }
+
+    res = aodvv2_find_route(&orig_addr, &target_addr);
     if (res < 0) {
         printf("%s: failed!\n", argv[0]);
         goto exit;


### PR DESCRIPTION
Hoooray! This enables the basic functionality of AODVv2 to send packets over the IEEE 802.15.4g interface, it can route packets effectively :D :tada: .

Future PRs will expand the AODVv2 protocol to keep up with the standards.