### PR TITLE
aodvv2: rename routingtable to lrs

### DIFF
--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * Copyright (C) 2020 Locha Inc
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,17 +9,17 @@
  */
 
 /**
- * @ingroup     aodvv2
+ * @ingroup     net_aodvv2
  * @{
  *
- * @file        routingtable.h
- * @brief       Cobbled-together routing table.
+ * @brief       AODVv2 Local Route Set
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef AODVV2_ROUTINGTABLE_H
-#define AODVV2_ROUTINGTABLE_H
+#ifndef AODVV2_LRS_H
+#define AODVV2_LRS_H
 
 #include <string.h>
 
@@ -154,4 +155,4 @@ void aodvv2_routingtable_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_da
 } /* extern "C" */
 #endif
 
-#endif /* AODVV2_ROUTINGTABLE_H  */
+#endif /* AODVV2_LRS_H  */

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -24,7 +24,7 @@
 #include "net/aodvv2/rfc5444.h"
 #include "net/aodvv2/client.h"
 #include "net/aodvv2/metric.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 #include "net/aodvv2/rreqtable.h"
 #include "net/aodvv2/seqnum.h"
 

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -20,7 +20,7 @@
  */
 
 #include "net/aodvv2/aodvv2.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -25,7 +25,7 @@
 #include "net/aodvv2/client.h"
 #include "net/aodvv2/metric.h"
 #include "net/aodvv2/rfc5444.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 #include "net/aodvv2/rreqtable.h"
 #include "net/manet/manet.h"
 


### PR DESCRIPTION
The name stands for Local Route Set.

This is just a better, name, I'm in the process of updating this implementation to match the last AODVv2 draft.