### PR TITLE
 aodvv2: safely compare Sequence Numbers 

### DIFF
--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin
  * Copyright (C) 2014 Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * Copyright (C) 2020 Locha Inc
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -8,17 +9,17 @@
  */
 
 /**
- * @ingroup     aodvv2
+ * @ingroup     net_aodvv2
  * @{
  *
- * @file        routingtable.h
- * @brief       Cobbled-together routing table.
+ * @brief       AODVv2 Local Route Set
  *
  * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
  */
 
-#ifndef AODVV2_ROUTINGTABLE_H
-#define AODVV2_ROUTINGTABLE_H
+#ifndef AODVV2_LRS_H
+#define AODVV2_LRS_H
 
 #include <string.h>
 
@@ -154,4 +155,4 @@ void aodvv2_routingtable_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_da
 } /* extern "C" */
 #endif
 
-#endif /* AODVV2_ROUTINGTABLE_H  */
+#endif /* AODVV2_LRS_H  */

--- a/sys/include/net/aodvv2/seqnum.h
+++ b/sys/include/net/aodvv2/seqnum.h
@@ -50,18 +50,23 @@ void aodvv2_seqnum_inc(void);
 aodvv2_seqnum_t aodvv2_seqnum_get(void);
 
 /**
- * @brief   Compare 2 sequence numbers.
+ * @brief   Compare sequence numbers
  *
- * @param[in] s1 First sequence number
- * @param[in] s2 Second sequence number
+ * @see <a href="https://tools.ietf.org/html/draft-perkins-manet-aodvv2-03#section-4.4">
+ *          draft-perkins-manet-aodvv2-03, Section 4.4. Sequence Numbers
+ *      </a>
  *
- * @return -1, s1 is smaller.
- * @return  0, s1 and s2 are equal.
- * @return  1, s1 is bigger.
+ * @param[in] existing Known sequence number.
+ * @param[in] received Newly received sequence number.
+ *
+ * @return <0 Received sequence number is older.
+ * @return >0 Received sequence number is newer.
+ * @return 0  Existing sequence number is equal to the received.
  */
-static inline int aodvv2_seqnum_cmp(aodvv2_seqnum_t s1, aodvv2_seqnum_t s2)
+static inline int16_t aodvv2_seqnum_cmp(aodvv2_seqnum_t existing,
+                                        aodvv2_seqnum_t received)
 {
-    return s1 == s2 ? 0 : (s1 > s2 ? +1 : -1);
+    return (int16_t)((int32_t)received - (int32_t)existing);
 }
 
 #ifdef __cplusplus

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -24,7 +24,7 @@
 #include "net/aodvv2/rfc5444.h"
 #include "net/aodvv2/client.h"
 #include "net/aodvv2/metric.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 #include "net/aodvv2/rreqtable.h"
 #include "net/aodvv2/seqnum.h"
 

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -20,7 +20,7 @@
  */
 
 #include "net/aodvv2/aodvv2.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -165,7 +165,7 @@ bool aodvv2_routingtable_offers_improvement(aodvv2_local_route_t *rt_entry,
                                             node_data_t *node_data)
 {
     /* Check if new info is stale */
-    if (aodvv2_seqnum_cmp(node_data->seqnum, rt_entry->seqnum) == -1) {
+    if (aodvv2_seqnum_cmp(node_data->seqnum, rt_entry->seqnum) < 0) {
         return false;
     }
     /* Check if new info is more costly */

--- a/sys/net/aodvv2/aodvv2_rreqtable.c
+++ b/sys/net/aodvv2/aodvv2_rreqtable.c
@@ -75,11 +75,11 @@ bool aodvv2_rreqtable_is_redundant(aodvv2_packet_data_t *packet_data)
          * metric type and OrigNode and Targnode addresses, the information from
          * the one with the older Sequence Number is not needed in the table
          */
-        if (seqnum_comparison == -1) {
+        if (seqnum_comparison < 0) {
             result = true;
         }
 
-        if (seqnum_comparison == 1) {
+        if (seqnum_comparison > 0) {
             /* Update RREQ table entry with new seqnum value */
             comparable_rreq->seqnum = packet_data->orig_node.seqnum;
         }

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -25,7 +25,7 @@
 #include "net/aodvv2/client.h"
 #include "net/aodvv2/metric.h"
 #include "net/aodvv2/rfc5444.h"
-#include "net/aodvv2/routingtable.h"
+#include "net/aodvv2/lrs.h"
 #include "net/aodvv2/rreqtable.h"
 #include "net/manet/manet.h"
 


### PR DESCRIPTION
This is how the AODVv2 draft specifies that Sequence Numbers _should_ be
compared.

The draft specifies that the sequence numbers should be subtracted in order to correctly compare the numbers, and interpret them as `int16_t` integers (using internally `int32_t` to avoid overflows or underflows).

This is an step to catch up with the spec.

Depends on #84