### PR TITLE
aodvv2: don't release gnrc_pktsnip_t

### DIFF
--- a/sys/net/aodvv2/aodvv2_buffer.c
+++ b/sys/net/aodvv2/aodvv2_buffer.c
@@ -41,7 +41,6 @@ static void _pkt_del(unsigned i)
     buffered_pkt_t *entry = &_buffered_pkts[i];
     if (entry->used) {
         entry->used = false;
-        gnrc_pktbuf_release(entry->pkt);
         entry->pkt = NULL;
         entry->dst = ipv6_addr_unspecified;
     }


### PR DESCRIPTION
This caused a crash on the updated commit of RIOT (#81 ), probably an assert was added to catch these types of error.