### PR TITLE
aodvv2: add lrs_entry_t wrapper

### DIFF
--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -57,7 +57,7 @@ enum aodvv2_routing_state {
 };
 
 /**
- * @brief   All fields of a routing table entry
+ * @brief   All fields of a Local Route entry
  */
 typedef struct {
     struct netaddr addr; /**< IP address of this route's destination */
@@ -74,82 +74,82 @@ typedef struct {
 } aodvv2_local_route_t;
 
 /**
- * @brief     Initialize routing table.
+ * @brief     Initialize Local Route Set.
  */
-void aodvv2_routingtable_init(void);
+void aodvv2_lrs_init(void);
 
 /**
  * @brief     Get next hop towards dest.
- *            Returns NULL if dest is not in routing table.
  *
  * @param[in] dest        Destination of the packet
  * @param[in] metricType  Metric Type of the desired route
- * @return                next hop towards dest if it exists, NULL otherwise
+ *
+ * @return Next hop towards dest if it exists, NULL otherwise.
  */
-struct netaddr *aodvv2_routingtable_get_next_hop(struct netaddr *dest,
+struct netaddr *aodvv2_lrs_get_next_hop(struct netaddr *dest,
                                                  routing_metric_t metricType);
 
 /**
- * @brief     Add new entry to routing table, if there is no other entry
+ * @brief     Add new entry to Local Route, if there is no other entry
  *            to the same destination.
  *
- * @param[in] entry        The routing table entry to add
+ * @param[in] entry The Local Route to add.
  */
-void aodvv2_routingtable_add_entry(aodvv2_local_route_t *entry);
+void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry);
 
 /**
- * @brief     Retrieve pointer to a routing table entry.
- *            To edit, simply follow the pointer.
- *            Returns NULL if addr is not in routing table.
+ * @brief     Retrieve pointer to a Local Route entry.
  *
  * @param[in] addr          The address towards which the route should point
  * @param[in] metricType    Metric Type of the desired route
- * @return                  Routing table entry if it exists, NULL otherwise
+ *
+ * @return Local Route if it exists, NULL otherwise
  */
-aodvv2_local_route_t *aodvv2_routingtable_get_entry(struct netaddr *addr,
-                                                      routing_metric_t metricType);
+aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
+                                           routing_metric_t metricType);
 
 /**
- * @brief     Delete routing table entry towards addr with metric type MetricType,
+ * @brief     Delete Local Route entry towards addr with metric type MetricType,
  *            if it exists.
  *
- * @param[in] addr          The address towards which the route should point
- * @param[in] metricType    Metric Type of the desired route
+ * @param[in] addr       The address towards which the route should point
+ * @param[in] metricType Metric Type of the desired route
  */
-void aodvv2_routingtable_delete_entry(struct netaddr *addr, routing_metric_t metricType);
+void aodvv2_lrs_delete_entry(struct netaddr *addr, routing_metric_t metricType);
 
 /**
- * Check if the data of a RREQ or RREP offers improvement for an existing routing
- * table entry.
- * @param rt_entry            the routing table entry to check
- * @param node_data           The data to check against. When handling a RREQ,
- *                            the OrigNode's information (i.e. packet_data.origNode)
- *                            must be passed. When handling a RREP, the
- *                            TargNode's data (i.e. packet_data.targNode) must
- *                            be passed.
+ * @brief   Check if the data of a RREQ or RREP offers improvement for an
+ *          existing Local Route entry.
+ *
+ * @param[in] rt_entry  The Local Route to check.
+ * @param[in] node_data The data to check against.
+ *
+ * @return true if offers improvement, false otherwise.
  */
-bool aodvv2_routingtable_offers_improvement(aodvv2_local_route_t *rt_entry,
-                                            node_data_t *node_data);
+bool aodvv2_lrs_offers_improvement(aodvv2_local_route_t *rt_entry,
+                                   node_data_t *node_data);
 
 /**
- * Fills a routing table entry with the data of a RREQ.
- * @param packet_data         the RREQ's data
- * @param rt_entry            the routing table entry to fill
- * @param link_cost           the link cost for this RREQ
+ * @brief   Fills a Local Route entry with the data of a RREQ.
+ *
+ * @param[in]  packet_data The RREQ's data
+ * @param[out] rt_entry    The Local Route entry to fill
+ * @param[in]  link_cost   The link cost for this RREQ
  */
-void aodvv2_routingtable_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
-                                                 aodvv2_local_route_t *rt_entry,
-                                                 uint8_t link_cost);
+void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
+                                        aodvv2_local_route_t *rt_entry,
+                                        uint8_t link_cost);
 
 /**
- * Fills a routing table entry with the data of a RREP.
- * @param packet_data         the RREP's data
- * @param rt_entry            the routing table entry to fill
- * @param link_cost           the link cost for this RREP
+ * @brief   Fills a Local Route entry with the data of a RREP.
+ *
+ * @param[in]  packet_data The RREP's data
+ * @param[out] rt_entry    The Local Route entry to fill
+ * @param[in]  link_cost   The link cost for this RREP
  */
-void aodvv2_routingtable_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
-                                                 aodvv2_local_route_t *rt_entry,
-                                                 uint8_t link_cost);
+void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
+                                        aodvv2_local_route_t *rt_entry,
+                                        uint8_t link_cost);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sys/include/net/aodvv2/seqnum.h
+++ b/sys/include/net/aodvv2/seqnum.h
@@ -50,18 +50,23 @@ void aodvv2_seqnum_inc(void);
 aodvv2_seqnum_t aodvv2_seqnum_get(void);
 
 /**
- * @brief   Compare 2 sequence numbers.
+ * @brief   Compare sequence numbers
  *
- * @param[in] s1 First sequence number
- * @param[in] s2 Second sequence number
+ * @see <a href="https://tools.ietf.org/html/draft-perkins-manet-aodvv2-03#section-4.4">
+ *          draft-perkins-manet-aodvv2-03, Section 4.4. Sequence Numbers
+ *      </a>
  *
- * @return -1, s1 is smaller.
- * @return  0, s1 and s2 are equal.
- * @return  1, s1 is bigger.
+ * @param[in] existing Known sequence number.
+ * @param[in] received Newly received sequence number.
+ *
+ * @return <0 Received sequence number is older.
+ * @return >0 Received sequence number is newer.
+ * @return 0  Existing sequence number is equal to the received.
  */
-static inline int aodvv2_seqnum_cmp(aodvv2_seqnum_t s1, aodvv2_seqnum_t s2)
+static inline int16_t aodvv2_seqnum_cmp(aodvv2_seqnum_t existing,
+                                        aodvv2_seqnum_t received)
 {
-    return s1 == s2 ? 0 : (s1 > s2 ? +1 : -1);
+    return (int16_t)((int32_t)received - (int32_t)existing);
 }
 
 #ifdef __cplusplus

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -378,7 +378,7 @@ int aodvv2_init(gnrc_netif_t *netif)
 
     /* Initialize AODVv2 internal structures */
     aodvv2_seqnum_init();
-    aodvv2_routingtable_init();
+    aodvv2_lrs_init();
     aodvv2_client_init();
     aodvv2_rreqtable_init();
     aodvv2_buffer_init();

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -39,9 +39,9 @@ static timex_t max_idletime;
 static timex_t validity_t;
 static timex_t now;
 
-void aodvv2_routingtable_init(void)
+void aodvv2_lrs_init(void)
 {
-    DEBUG("aodvv2_routingtable_init()\n");
+    DEBUG("aodvv2_lrs_init()\n");
 
     null_time = timex_set(0, 0);
     max_seqnum_lifetime = timex_set(CONFIG_AODVV2_MAX_SEQNUM_LIFETIME, 0);
@@ -53,19 +53,19 @@ void aodvv2_routingtable_init(void)
     memset(&routing_table, 0, sizeof(routing_table));
 }
 
-struct netaddr *aodvv2_routingtable_get_next_hop(struct netaddr *dest, routing_metric_t metricType)
+struct netaddr *aodvv2_lrs_get_next_hop(struct netaddr *dest, routing_metric_t metricType)
 {
-    aodvv2_local_route_t *entry = aodvv2_routingtable_get_entry(dest, metricType);
+    aodvv2_local_route_t *entry = aodvv2_lrs_get_entry(dest, metricType);
     if (!entry) {
         return NULL;
     }
     return (&entry->next_hop);
 }
 
-void aodvv2_routingtable_add_entry(aodvv2_local_route_t *entry)
+void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry)
 {
     /* only add if we don't already know the address */
-    if (aodvv2_routingtable_get_entry(&(entry->addr), entry->metricType)) {
+    if (aodvv2_lrs_get_entry(&(entry->addr), entry->metricType)) {
         return;
     }
     /*find free spot in RT and place rt_entry there */
@@ -77,7 +77,7 @@ void aodvv2_routingtable_add_entry(aodvv2_local_route_t *entry)
     }
 }
 
-aodvv2_local_route_t *aodvv2_routingtable_get_entry(struct netaddr *addr,
+aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
                                                       routing_metric_t metricType)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
@@ -91,7 +91,7 @@ aodvv2_local_route_t *aodvv2_routingtable_get_entry(struct netaddr *addr,
     return NULL;
 }
 
-void aodvv2_routingtable_delete_entry(struct netaddr *addr, routing_metric_t metricType)
+void aodvv2_lrs_delete_entry(struct netaddr *addr, routing_metric_t metricType)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
         _reset_entry_if_stale(i);
@@ -161,7 +161,7 @@ static void _reset_entry_if_stale(uint8_t i)
     }
 }
 
-bool aodvv2_routingtable_offers_improvement(aodvv2_local_route_t *rt_entry,
+bool aodvv2_lrs_offers_improvement(aodvv2_local_route_t *rt_entry,
                                             node_data_t *node_data)
 {
     /* Check if new info is stale */
@@ -180,7 +180,7 @@ bool aodvv2_routingtable_offers_improvement(aodvv2_local_route_t *rt_entry,
     return true;
 }
 
-void aodvv2_routingtable_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
                                                  aodvv2_local_route_t *rt_entry,
                                                  uint8_t link_cost)
 {
@@ -194,7 +194,7 @@ void aodvv2_routingtable_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_da
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }
 
-void aodvv2_routingtable_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
                                                  aodvv2_local_route_t *rt_entry,
                                                  uint8_t link_cost)
 {

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -165,7 +165,7 @@ bool aodvv2_routingtable_offers_improvement(aodvv2_local_route_t *rt_entry,
                                             node_data_t *node_data)
 {
     /* Check if new info is stale */
-    if (aodvv2_seqnum_cmp(node_data->seqnum, rt_entry->seqnum) == -1) {
+    if (aodvv2_seqnum_cmp(node_data->seqnum, rt_entry->seqnum) < 0) {
         return false;
     }
     /* Check if new info is more costly */

--- a/sys/net/aodvv2/aodvv2_rreqtable.c
+++ b/sys/net/aodvv2/aodvv2_rreqtable.c
@@ -75,11 +75,11 @@ bool aodvv2_rreqtable_is_redundant(aodvv2_packet_data_t *packet_data)
          * metric type and OrigNode and Targnode addresses, the information from
          * the one with the older Sequence Number is not needed in the table
          */
-        if (seqnum_comparison == -1) {
+        if (seqnum_comparison < 0) {
             result = true;
         }
 
-        if (seqnum_comparison == 1) {
+        if (seqnum_comparison > 0) {
             /* Update RREQ table entry with new seqnum value */
             comparable_rreq->seqnum = packet_data->orig_node.seqnum;
         }

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -230,17 +230,15 @@ static enum rfc5444_result _cb_rrep_end_callback(
     same MetricType of the RteMsg, matching RteMsg.Addr. */
 
     aodvv2_local_route_t *rt_entry =
-        aodvv2_routingtable_get_entry(&packet_data.targ_node.addr,
-                                      packet_data.metric_type);
+        aodvv2_lrs_get_entry(&packet_data.targ_node.addr,
+                             packet_data.metric_type);
 
     if (!rt_entry || (rt_entry->metricType != packet_data.metric_type)) {
         DEBUG("rfc5444_reader: creating new Routing Table entry...\n");
 
         aodvv2_local_route_t tmp = {0};
-        aodvv2_routingtable_fill_routing_entry_rrep(&packet_data,
-                                                    &tmp,
-                                                    link_cost);
-        aodvv2_routingtable_add_entry(&tmp);
+        aodvv2_lrs_fill_routing_entry_rrep(&packet_data, &tmp, link_cost);
+        aodvv2_lrs_add_entry(&tmp);
 
         /* Add entry to nib forwading table */
         ipv6_addr_t dst;
@@ -256,8 +254,7 @@ static enum rfc5444_result _cb_rrep_end_callback(
         }
     }
     else {
-        if (!aodvv2_routingtable_offers_improvement(rt_entry,
-                                                    &packet_data.targ_node)) {
+        if (!aodvv2_lrs_offers_improvement(rt_entry, &packet_data.targ_node)) {
             DEBUG("rfc5444_reader: RREP offers no improvement over known route.\n");
             return RFC5444_DROP_PACKET;
         }
@@ -265,9 +262,7 @@ static enum rfc5444_result _cb_rrep_end_callback(
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
         DEBUG("rfc5444_reader: updating Routing Table entry...\n");
-        aodvv2_routingtable_fill_routing_entry_rrep(&packet_data,
-                                                    rt_entry,
-                                                    link_cost);
+        aodvv2_lrs_fill_routing_entry_rrep(&packet_data, rt_entry, link_cost);
 
         /* Add entry to nib forwading table */
         ipv6_addr_t dst;
@@ -313,7 +308,7 @@ static enum rfc5444_result _cb_rrep_end_callback(
 
         ipv6_addr_t next_hop;
         struct netaddr *na_next_hop =
-            aodvv2_routingtable_get_next_hop(&packet_data.orig_node.addr,
+            aodvv2_lrs_get_next_hop(&packet_data.orig_node.addr,
                                              packet_data.metric_type);
         netaddr_to_ipv6_addr(na_next_hop, &next_hop);
         aodvv2_send_rrep(&packet_data, &next_hop);
@@ -455,8 +450,8 @@ static enum rfc5444_result _cb_rreq_end_callback(
      * same MetricType of the RteMsg, matching RteMsg.Addr.
      */
     aodvv2_local_route_t *rt_entry =
-        aodvv2_routingtable_get_entry(&packet_data.orig_node.addr,
-                                      packet_data.metric_type);
+        aodvv2_lrs_get_entry(&packet_data.orig_node.addr,
+                             packet_data.metric_type);
 
     if (!rt_entry || (rt_entry->metricType != packet_data.metric_type)) {
         DEBUG("rfc5444_reader: creating new Routing Table entry...\n");
@@ -464,8 +459,8 @@ static enum rfc5444_result _cb_rreq_end_callback(
         aodvv2_local_route_t tmp = {0};
 
         /* Add this RREQ to routing table*/
-        aodvv2_routingtable_fill_routing_entry_rreq(&packet_data, &tmp, link_cost);
-        aodvv2_routingtable_add_entry(&tmp);
+        aodvv2_lrs_fill_routing_entry_rreq(&packet_data, &tmp, link_cost);
+        aodvv2_lrs_add_entry(&tmp);
 
         /* Add entry to nib forwading table */
         ipv6_addr_t dst;
@@ -483,8 +478,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
     else {
         /* If the route is aready stored verify if this route offers an
          * improvement in path*/
-        if (!aodvv2_routingtable_offers_improvement(rt_entry,
-                                                    &packet_data.orig_node)) {
+        if (!aodvv2_lrs_offers_improvement(rt_entry, &packet_data.orig_node)) {
             DEBUG("rfc5444_reader: packet offers no improvement over known route.\n");
             return RFC5444_DROP_PACKET;
         }
@@ -492,8 +486,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
         DEBUG("rfc5444_reader: updating Routing Table entry...\n");
-        aodvv2_routingtable_fill_routing_entry_rreq(&packet_data, rt_entry,
-                                                    link_cost);
+        aodvv2_lrs_fill_routing_entry_rreq(&packet_data, rt_entry, link_cost);
 
         /* Add entry to nib forwading table */
         ipv6_addr_t dst;


### PR DESCRIPTION
This is in order to not depend on `struct netaddr`, the code looks ugly right now, this is an step to refactor this code.