### PR TITLE
radio-firmware: don't initalize chat if not needed

### DIFF
--- a/main.c
+++ b/main.c
@@ -59,7 +59,10 @@ int main(void)
         printf("Couldn't initialize RFC5444\n");
     }
 
+    /* Initialize chat */
+#if IS_USED(MODULE_CHAT)
     chat_init(ieee802154_netif);
+#endif
 
     puts("Welcome to Turpial CC1312 Radio!");
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,6 +1,8 @@
 MODULE = radio_firmware_sys
 
-DIRS += chat
+ifneq (,$(filter chat,$(USEMODULE)))
+  DIRS += chat
+endif
 DIRS += shell_extended
 DIRS += net
 DIRS += oonf_api


### PR DESCRIPTION
This way `USEMODULE += chat` can be commented without changing too much code.