### PR TITLE
aodvv2: use IPv6 on rreqtable/packet/lrs

### DIFF
--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -23,8 +23,6 @@
 
 #include <string.h>
 
-#include "common/netaddr.h"
-
 #include "net/aodvv2/aodvv2.h"
 #include "net/aodvv2/rfc5444.h"
 #include "net/aodvv2/seqnum.h"
@@ -60,11 +58,11 @@ enum aodvv2_routing_state {
  * @brief   All fields of a Local Route entry
  */
 typedef struct {
-    struct netaddr addr; /**< IP address of this route's destination */
+    ipv6_addr_t addr; /**< IP address of this route's destination */
     aodvv2_seqnum_t seqnum; /**< The Sequence Number obtained from the
                                  last packet that updated the entry */
-    struct netaddr next_hop; /**< IP address of the the next hop towards the
-                                     destination */
+    ipv6_addr_t next_hop; /**< IP address of the the next hop towards the
+                               destination */
     timex_t last_used; /**< IP address of this route's destination */
     timex_t expiration_time; /**< Time at which this route expires */
     routing_metric_t metricType; /**< Metric type of this route */
@@ -86,8 +84,8 @@ void aodvv2_lrs_init(void);
  *
  * @return Next hop towards dest if it exists, NULL otherwise.
  */
-struct netaddr *aodvv2_lrs_get_next_hop(struct netaddr *dest,
-                                                 routing_metric_t metricType);
+ipv6_addr_t *aodvv2_lrs_get_next_hop(ipv6_addr_t *dest,
+                                     routing_metric_t metricType);
 
 /**
  * @brief     Add new entry to Local Route, if there is no other entry
@@ -100,12 +98,12 @@ void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry);
 /**
  * @brief     Retrieve pointer to a Local Route entry.
  *
- * @param[in] addr          The address towards which the route should point
- * @param[in] metricType    Metric Type of the desired route
+ * @param[in] addr       The address towards which the route should point
+ * @param[in] metricType Metric Type of the desired route
  *
  * @return Local Route if it exists, NULL otherwise
  */
-aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
+aodvv2_local_route_t *aodvv2_lrs_get_entry(ipv6_addr_t *addr,
                                            routing_metric_t metricType);
 
 /**
@@ -115,7 +113,7 @@ aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
  * @param[in] addr       The address towards which the route should point
  * @param[in] metricType Metric Type of the desired route
  */
-void aodvv2_lrs_delete_entry(struct netaddr *addr, routing_metric_t metricType);
+void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metricType);
 
 /**
  * @brief   Check if the data of a RREQ or RREP offers improvement for an

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -105,7 +105,7 @@ typedef enum {
  * @brief   Data about an OrigNode or TargNode.
  */
 typedef struct {
-    struct netaddr addr; /**< IP address of the node */
+    ipv6_addr_t addr; /**< IP address of the node */
     uint8_t metric; /**< Metric value */
     aodvv2_seqnum_t seqnum; /**< Sequence Number */
 } node_data_t;
@@ -115,8 +115,8 @@ typedef struct {
  */
 typedef struct {
     uint8_t hoplimit; /**< Hop limit */
-    struct netaddr sender; /**< IP address of the neighboring router
-                                which sent the RREQ/RREP*/
+    ipv6_addr_t sender; /**< IP address of the neighboring router which sent the
+                             RREQ/RREP*/
     routing_metric_t metric_type; /**< Metric type */
     node_data_t orig_node; /**< Data about the originating node */
     node_data_t targ_node; /**< Data about the originating node */

--- a/sys/include/net/aodvv2/rreqtable.h
+++ b/sys/include/net/aodvv2/rreqtable.h
@@ -27,8 +27,6 @@
 #include "net/aodvv2/seqnum.h"
 #include "net/aodvv2/rfc5444.h"
 
-#include "common/netaddr.h"
-
 #include "timex.h"
 
 #ifdef __cplusplus
@@ -50,8 +48,8 @@ extern "C" {
  *          received in order to avoid duplicates.
  */
 typedef struct {
-    struct netaddr origNode; /**< Node which originated the RREQ*/
-    struct netaddr targNode; /**< Target (destination) of the RREQ */
+    ipv6_addr_t origNode; /**< Node which originated the RREQ*/
+    ipv6_addr_t targNode; /**< Target (destination) of the RREQ */
     routing_metric_t metricType; /**< Metric type of the RREQ */
     uint8_t metric; /**< Metric of the RREQ */
     aodvv2_seqnum_t seqnum; /**< Sequence number of the RREQ */

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -514,13 +514,13 @@ int aodvv2_find_route(const ipv6_addr_t *orig_addr,
     pkt.metric_type = CONFIG_AODVV2_DEFAULT_METRIC;
 
     /* Set OrigNode information */
-    ipv6_addr_to_netaddr(orig_addr, &pkt.orig_node.addr);
+    pkt.orig_node.addr = *orig_addr;
     pkt.orig_node.metric = 0;
     pkt.orig_node.seqnum = aodvv2_seqnum_get();
     aodvv2_seqnum_inc();
 
     /* Set TargNode information */
-    ipv6_addr_to_netaddr(target_addr, &pkt.targ_node.addr);
+    pkt.targ_node.addr = *target_addr;
     pkt.targ_node.metric = 0;
     pkt.targ_node.seqnum = 0;
 

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -22,7 +22,7 @@
 #include "net/aodvv2/aodvv2.h"
 #include "net/aodvv2/lrs.h"
 
-#define ENABLE_DEBUG (1)
+#define ENABLE_DEBUG (0)
 #include "debug.h"
 
 static void _reset_entry_if_stale(uint8_t i);
@@ -64,8 +64,8 @@ void aodvv2_lrs_init(void)
     memset(&routing_table, 0, sizeof(routing_table));
 }
 
-struct netaddr *aodvv2_lrs_get_next_hop(struct netaddr *dest,
-                                        routing_metric_t metricType)
+ipv6_addr_t *aodvv2_lrs_get_next_hop(ipv6_addr_t *dest,
+                                     routing_metric_t metricType)
 {
     aodvv2_local_route_t *entry = aodvv2_lrs_get_entry(dest, metricType);
     if (!entry) {
@@ -77,7 +77,7 @@ struct netaddr *aodvv2_lrs_get_next_hop(struct netaddr *dest,
 void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry)
 {
     /* only add if we don't already know the address */
-    if (aodvv2_lrs_get_entry(&(entry->addr), entry->metricType)) {
+    if (aodvv2_lrs_get_entry(&entry->addr, entry->metricType)) {
         return;
     }
     /*find free spot in RT and place rt_entry there */
@@ -90,13 +90,13 @@ void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry)
     }
 }
 
-aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
+aodvv2_local_route_t *aodvv2_lrs_get_entry(ipv6_addr_t *addr,
                                            routing_metric_t metricType)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
         _reset_entry_if_stale(i);
 
-        if (!netaddr_cmp(&routing_table[i].route.addr, addr) &&
+        if (ipv6_addr_equal(&routing_table[i].route.addr, addr) &&
             routing_table[i].route.metricType == metricType) {
             return &routing_table[i].route;
         }
@@ -104,13 +104,13 @@ aodvv2_local_route_t *aodvv2_lrs_get_entry(struct netaddr *addr,
     return NULL;
 }
 
-void aodvv2_lrs_delete_entry(struct netaddr *addr, routing_metric_t metricType)
+void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metricType)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
         _reset_entry_if_stale(i);
 
         if (routing_table[i].used) {
-            if (!netaddr_cmp(&routing_table[i].route.addr, addr) &&
+            if (ipv6_addr_equal(&routing_table[i].route.addr, addr) &&
                 routing_table[i].route.metricType == metricType) {
                 memset(&routing_table[i].route, 0, sizeof(aodvv2_local_route_t));
                 routing_table[i].used = false;
@@ -211,8 +211,8 @@ void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
 }
 
 void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
-                                                 aodvv2_local_route_t *rt_entry,
-                                                 uint8_t link_cost)
+                                        aodvv2_local_route_t *rt_entry,
+                                        uint8_t link_cost)
 {
     rt_entry->addr = packet_data->targ_node.addr;
     rt_entry->seqnum = packet_data->targ_node.seqnum;

--- a/sys/net/aodvv2/aodvv2_rreqtable.c
+++ b/sys/net/aodvv2/aodvv2_rreqtable.c
@@ -38,8 +38,6 @@ static timex_t _null_time;
 static timex_t now;
 static timex_t _max_idletime;
 
-static struct netaddr_str nbuf;
-
 void aodvv2_rreqtable_init(void)
 {
     DEBUG("aodvv2_rreqtable_init()\n");
@@ -118,8 +116,8 @@ static aodvv2_rreq_entry_t *_get_comparable_rreq(aodvv2_packet_data_t *packet_da
     for (unsigned i = 0; i < ARRAY_SIZE(rreq_table); i++) {
         _reset_entry_if_stale(i);
 
-        if (!netaddr_cmp(&rreq_table[i].origNode, &packet_data->orig_node.addr) &&
-            !netaddr_cmp(&rreq_table[i].targNode, &packet_data->targ_node.addr) &&
+        if (ipv6_addr_equal(&rreq_table[i].origNode, &packet_data->orig_node.addr) &&
+            ipv6_addr_equal(&rreq_table[i].targNode, &packet_data->targ_node.addr) &&
             rreq_table[i].metricType == packet_data->metric_type) {
             return &rreq_table[i];
         }
@@ -163,9 +161,6 @@ static void _reset_entry_if_stale(uint8_t i)
 
     timex_t expiration_time = timex_add(rreq_table[i].timestamp, _max_idletime);
     if (timex_cmp(expiration_time, now) < 0) {
-        /* timestamp+expiration time is in the past: this entry is stale */
-        DEBUG("_reset_entry_if_stale: entry %s is stale, resettings\n",
-              netaddr_to_string(&nbuf, &rreq_table[i].origNode));
         memset(&rreq_table[i], 0, sizeof(rreq_table[i]));
     }
 }

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -89,17 +89,20 @@ static void _cb_add_message_header(struct rfc5444_writer *wr,
 static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)
 {
     struct rfc5444_writer_address *orig_node_addr;
+    struct netaddr tmp;
 
     /* add orig_node address (has no address tlv); is mandatory address */
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, &tmp);
     orig_node_addr =
         rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
-                                   &_target->packet_data.orig_node.addr, true);
+                                   &tmp, true);
 
     assert(orig_node_addr != NULL);
 
     /* add targ_node address (has no address tlv); is mandatory address */
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, &tmp);
     rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
-                               &_target->packet_data.targ_node.addr, true);
+                               &tmp, true);
 
     /* add SeqNum TLV and metric TLV to OrigNode */
     rfc5444_writer_add_addrtlv(wr, orig_node_addr,
@@ -119,6 +122,7 @@ static void _cb_rrep_add_addresses(struct rfc5444_writer *wr)
 {
     struct rfc5444_writer_address *orig_node_addr;
     struct rfc5444_writer_address *targ_node_addr;
+    struct netaddr tmp;
 
     uint16_t orig_node_seqnum = _target->packet_data.orig_node.seqnum;
     uint16_t targ_node_seqnum = aodvv2_seqnum_get();
@@ -126,16 +130,18 @@ static void _cb_rrep_add_addresses(struct rfc5444_writer *wr)
     uint8_t targ_node_hopct = _target->packet_data.targ_node.metric;
 
     /* add orig_node address (has no address tlv); is mandatory address */
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, &tmp);
     orig_node_addr =
         rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
-                                   &_target->packet_data.orig_node.addr, true);
+                                   &tmp, true);
 
     assert(orig_node_addr != NULL);
 
     /* add targ_node address (has no address tlv); is mandatory address */
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, &tmp);
     targ_node_addr =
         rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
-                                   &_target->packet_data.targ_node.addr, true);
+                                   &tmp, true);
 
     assert(targ_node_addr != NULL);
 


### PR DESCRIPTION
This is a switch from `struct netaddr` to `ipv6_addr_t`, now only
conversions are made when writing/reading RFC 5444 packets.

Should be more performant.

- PR branch
```
   text	  data	   bss	   dec	   hex	filename
  95476	  1988	 27004	124468	 1e634	/home/jeandudey/Dev/radio-firmware/bin/cc2538dk/radio-firmware.elf
```

- `dev` branch
```
   text	  data	   bss	   dec	   hex	filename
  95764	  1988	 27140	124892	 1e7dc	/home/jeandudey/Dev/radio-firmware/bin/cc2538dk/radio-firmware.elf
```

Reduces `.text` by 288 bytes. `.bss` is also 136 bytes less.