### PR TITLE
aodvv2: use prefix length correctly

### DIFF
--- a/sys/include/net/aodvv2/aodvv2.h
+++ b/sys/include/net/aodvv2/aodvv2.h
@@ -59,11 +59,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   AODVv2 prefix length
- */
-#define AODVV2_PREFIX_LEN (128)
-
-/**
  * @brief   IPC message to send a RREQ
  */
 #define AODVV2_MSG_TYPE_SEND_RREQ (0x9000)

--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -59,6 +59,7 @@ enum aodvv2_routing_state {
  */
 typedef struct {
     ipv6_addr_t addr; /**< IP address of this route's destination */
+    uint8_t pfx_len;  /**< Prefix length */
     aodvv2_seqnum_t seqnum; /**< The Sequence Number obtained from the
                                  last packet that updated the entry */
     ipv6_addr_t next_hop; /**< IP address of the the next hop towards the
@@ -130,22 +131,22 @@ bool aodvv2_lrs_offers_improvement(aodvv2_local_route_t *rt_entry,
 /**
  * @brief   Fills a Local Route entry with the data of a RREQ.
  *
- * @param[in]  packet_data The RREQ's data
- * @param[out] rt_entry    The Local Route entry to fill
- * @param[in]  link_cost   The link cost for this RREQ
+ * @param[in]  msg       The RREQ's data
+ * @param[out] rt_entry  The Local Route entry to fill
+ * @param[in]  link_cost The link cost for this RREQ
  */
-void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *msg,
                                         aodvv2_local_route_t *rt_entry,
                                         uint8_t link_cost);
 
 /**
  * @brief   Fills a Local Route entry with the data of a RREP.
  *
- * @param[in]  packet_data The RREP's data
- * @param[out] rt_entry    The Local Route entry to fill
- * @param[in]  link_cost   The link cost for this RREP
+ * @param[in]  msg       The RREP's data
+ * @param[out] rt_entry  The Local Route entry to fill
+ * @param[in]  link_cost The link cost for this RREP
  */
-void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *msg,
                                         aodvv2_local_route_t *rt_entry,
                                         uint8_t link_cost);
 

--- a/sys/include/net/aodvv2/lrs.h
+++ b/sys/include/net/aodvv2/lrs.h
@@ -55,21 +55,18 @@ enum aodvv2_routing_state {
 };
 
 /**
- * @brief   All fields of a Local Route entry
+ * @brief   A Local Route
  */
 typedef struct {
-    ipv6_addr_t addr; /**< IP address of this route's destination */
-    uint8_t pfx_len;  /**< Prefix length */
-    aodvv2_seqnum_t seqnum; /**< The Sequence Number obtained from the
-                                 last packet that updated the entry */
-    ipv6_addr_t next_hop; /**< IP address of the the next hop towards the
-                               destination */
-    timex_t last_used; /**< IP address of this route's destination */
-    timex_t expiration_time; /**< Time at which this route expires */
-    routing_metric_t metricType; /**< Metric type of this route */
-    uint8_t metric; /**< Metric value of this route*/
-    uint8_t state; /**< State of this route (i.e. one of
-                        aodvv2_routing_states) */
+    ipv6_addr_t addr;             /**< Destination IPv6 address */
+    uint8_t pfx_len;              /**< Prefix length */
+    aodvv2_seqnum_t seqnum;       /**< SeqNum associated with the IPv6 address */
+    ipv6_addr_t next_hop;         /**< Next hop IP address towards the destination */
+    timex_t last_used;            /**< Last time this route was used */
+    timex_t expiration_time;      /**< Time at which this route expires */
+    routing_metric_t metric_type; /**< Metric type of this route */
+    uint8_t metric;               /**< Metric value of this route*/
+    uint8_t state;                /**< State of this route */
 } aodvv2_local_route_t;
 
 /**
@@ -81,12 +78,12 @@ void aodvv2_lrs_init(void);
  * @brief     Get next hop towards dest.
  *
  * @param[in] dest        Destination of the packet
- * @param[in] metricType  Metric Type of the desired route
+ * @param[in] metric_type  Metric Type of the desired route
  *
  * @return Next hop towards dest if it exists, NULL otherwise.
  */
 ipv6_addr_t *aodvv2_lrs_get_next_hop(ipv6_addr_t *dest,
-                                     routing_metric_t metricType);
+                                     routing_metric_t metric_type);
 
 /**
  * @brief     Add new entry to Local Route, if there is no other entry
@@ -100,21 +97,21 @@ void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry);
  * @brief     Retrieve pointer to a Local Route entry.
  *
  * @param[in] addr       The address towards which the route should point
- * @param[in] metricType Metric Type of the desired route
+ * @param[in] metric_type Metric Type of the desired route
  *
  * @return Local Route if it exists, NULL otherwise
  */
 aodvv2_local_route_t *aodvv2_lrs_get_entry(ipv6_addr_t *addr,
-                                           routing_metric_t metricType);
+                                           routing_metric_t metric_type);
 
 /**
  * @brief     Delete Local Route entry towards addr with metric type MetricType,
  *            if it exists.
  *
  * @param[in] addr       The address towards which the route should point
- * @param[in] metricType Metric Type of the desired route
+ * @param[in] metric_type Metric Type of the desired route
  */
-void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metricType);
+void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metric_type);
 
 /**
  * @brief   Check if the data of a RREQ or RREP offers improvement for an

--- a/sys/include/net/aodvv2/rcs.h
+++ b/sys/include/net/aodvv2/rcs.h
@@ -120,9 +120,9 @@ aodvv2_rcs_entry_t *aodvv2_rcs_matches(const ipv6_addr_t *addr,
  *
  * @param[in] addr The IPv6 address.
  *
- * @return true if is a client, false otherwise.
+ * @return NULL if not found, otherwise pointer to RCS entry.
  */
-bool aodvv2_rcs_is_client(const ipv6_addr_t *addr);
+aodvv2_rcs_entry_t *aodvv2_rcs_is_client(const ipv6_addr_t *addr);
 
 /**
  * @brief   Print RCS entries.

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -144,7 +144,7 @@ void aodvv2_rfc5444_handle_packet_prepare(ipv6_addr_t *sender);
  * @param[in] writer Pointer to the writer context.
  * @param[in] target Pointer to the writer target.
  */
-void aodvv2_rfc5444_writer_register(struct rfc5444_writer *writer,
+void aodvv2_rfc5444_writer_register(struct rfc5444_writer *wr,
                                     aodvv2_writer_target_t *target);
 
 /**

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -39,56 +39,47 @@ extern "C" {
 
 /**
  * @name    RFC5444 thread stack size
- * @{
  */
 #ifndef CONFIG_AODVV2_RFC5444_STACK_SIZE
-#define CONFIG_AODVV2_RFC5444_STACK_SIZE (2048)
+#define CONFIG_AODVV2_RFC5444_STACK_SIZE     (2048)
 #endif
-/** @} */
 
 /**
  * @name    RFC5444 thread priority
- * @{
  */
 #ifndef CONFIG_AODVV2_RFC5444_PRIO
-#define CONFIG_AODVV2_RFC5444_PRIO (6)
+#define CONFIG_AODVV2_RFC5444_PRIO           (6)
 #endif
-/** @} */
 
 /**
  * @name    RFC5444 message queue size
- * @{
  */
 #ifndef CONFIG_AODVV2_RFC5444_MSG_QUEUE_SIZE
 #define CONFIG_AODVV2_RFC5444_MSG_QUEUE_SIZE (32)
 #endif
-/** @} */
 
 /**
  * @name    RFC5444 maximum packet size
- * @{
  */
 #ifndef CONFIG_AODVV2_RFC5444_PACKET_SIZE
-#define CONFIG_AODVV2_RFC5444_PACKET_SIZE (128)
+#define CONFIG_AODVV2_RFC5444_PACKET_SIZE    (128)
 #endif
-/** @} */
 
 /**
  * @name    RFC5444 address TLVs buffer size
- * @{
  */
 #ifndef CONFIG_AODVV2_RFC5444_ADDR_TLVS_SIZE
 #define CONFIG_AODVV2_RFC5444_ADDR_TLVS_SIZE (1000)
 #endif
-/** @} */
 
 /**
  * @brief   AODVv2 message types
  */
 typedef enum {
-    RFC5444_MSGTYPE_RREQ = 10, /**< RREQ message type */
-    RFC5444_MSGTYPE_RREP = 11, /**< RREP message type */
-    RFC5444_MSGTYPE_RERR = 12, /**< RERR message type */
+    RFC5444_MSGTYPE_RREQ = 10,    /**< RREQ message type */
+    RFC5444_MSGTYPE_RREP = 11,    /**< RREP message type */
+    RFC5444_MSGTYPE_RERR = 12,    /**< RERR message type */
+    RFC5444_MSGTYPE_RREP_ACK = 13 /**< RREP_Ack message type */
 } rfc5444_msg_type_t;
 
 /**
@@ -105,34 +96,29 @@ typedef enum {
  * @brief   Data about an OrigNode or TargNode.
  */
 typedef struct {
-    ipv6_addr_t addr; /**< IP address of the node */
-    uint8_t metric; /**< Metric value */
-    aodvv2_seqnum_t seqnum; /**< Sequence Number */
+    ipv6_addr_t addr;             /**< IPv6 address of the node */
+    uint8_t pfx_len;              /**< IPv6 address length */
+    uint8_t metric;               /**< Metric value */
+    aodvv2_seqnum_t seqnum;       /**< Sequence Number */
 } node_data_t;
 
 /**
  * @brief   All data contained in a RREQ or RREP.
  */
 typedef struct {
-    uint8_t hoplimit; /**< Hop limit */
-    ipv6_addr_t sender; /**< IP address of the neighboring router which sent the
-                             RREQ/RREP*/
+    uint8_t hoplimit;             /**< Hop limit */
+    ipv6_addr_t sender;           /**< IP address of the neighboring router */
     routing_metric_t metric_type; /**< Metric type */
-    node_data_t orig_node; /**< Data about the originating node */
-    node_data_t targ_node; /**< Data about the originating node */
-    timex_t timestamp; /**< Point at which the packet was (roughly)
-                            received. Note that this timestamp
-                            will be set after the packet has been
-                            successfully parsed. */
+    node_data_t orig_node;        /**< OrigNode data */
+    node_data_t targ_node;        /**< TargNode data */
+    timex_t timestamp;            /**< Time at which the message was received */
 } aodvv2_packet_data_t;
 
 typedef struct {
-    /** Interface for generating RFC5444 packets */
-    struct rfc5444_writer_target target;
-    /** Address to which the packet should be sent */
-    ipv6_addr_t target_addr;
-    aodvv2_packet_data_t packet_data; /**< Payload of the AODVv2 Message */
-    int type; /**< Type of the AODVv2 Message (i.e. rfc5444_msg_type) */
+    struct rfc5444_writer_target target; /**< RFC5444 writer target */
+    ipv6_addr_t target_addr;             /**< Address where the packet will be sent */
+    aodvv2_packet_data_t packet_data;    /**< Payload of the AODVv2 Message */
+    int type;                            /**< AODVV2 message type */
 } aodvv2_writer_target_t;
 
 /**
@@ -166,20 +152,24 @@ void aodvv2_rfc5444_writer_register(struct rfc5444_writer *writer,
  *
  * @pre (@p src != NULL) && (@p dst != NULL)
  *
- * @param[in] src  Source.
- * @param[out] dst Destination.
+ * @param[in]  src     Source.
+ * @param[in]  pfx_len Prefix length.
+ * @param[out] dst     Destination.
  */
-void ipv6_addr_to_netaddr(const ipv6_addr_t *src, struct netaddr *dst);
+void ipv6_addr_to_netaddr(const ipv6_addr_t *src, uint8_t pfx_len,
+                          struct netaddr *dst);
 
 /**
  * @brief   `struct netaddr` to `ipv6_addr_t`.
  *
  * @pre (@p src != NULL) && (@p dst != NULL)
  *
- * @param[in] src  Source.
- * @param[out] dst Destination.
+ * @param[in]  src     Source.
+ * @param[out] dst     Destination.
+ * @param[out] pfx_len Prefix length.
  */
-void netaddr_to_ipv6_addr(struct netaddr *src, ipv6_addr_t *dst);
+void netaddr_to_ipv6_addr(struct netaddr *src, ipv6_addr_t *dst,
+                          uint8_t *pfx_len);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -106,7 +106,7 @@ typedef struct {
  * @brief   All data contained in a RREQ or RREP.
  */
 typedef struct {
-    uint8_t hoplimit;             /**< Hop limit */
+    uint8_t msg_hop_limit;        /**< Hop limit */
     ipv6_addr_t sender;           /**< IP address of the neighboring router */
     routing_metric_t metric_type; /**< Metric type */
     node_data_t orig_node;        /**< OrigNode data */

--- a/sys/include/net/metric.h
+++ b/sys/include/net/metric.h
@@ -34,13 +34,13 @@
  */
 typedef enum {
      METRIC_NODE_STATE_AND_ATTRIBUTE = 1, /**< Node State and Attribute */
-     METRIC_NODE_ENERGY = 2, /**< Node Energy */
-     METRIC_HOP_COUNT = 3, /**< Hop Count */
-     METRIC_LINK_TROUGHPUT = 4, /**< Link Troughput */
-     METRIC_LINK_LATENCY = 5, /**< Link Latency */
-     METRIC_LINK_QUALITY_LEVEL = 6, /**< Link Quality Level */
-     METRIC_LINK_ETX = 7, /**< Link ETX*/
-     METRIC_LINK_COLOR = 8, /**< Link Color */
+     METRIC_NODE_ENERGY = 2,              /**< Node Energy */
+     METRIC_HOP_COUNT = 3,                /**< Hop Count */
+     METRIC_LINK_TROUGHPUT = 4,           /**< Link Troughput */
+     METRIC_LINK_LATENCY = 5,             /**< Link Latency */
+     METRIC_LINK_QUALITY_LEVEL = 6,       /**< Link Quality Level */
+     METRIC_LINK_ETX = 7,                 /**< Link ETX*/
+     METRIC_LINK_COLOR = 8,               /**< Link Color */
 } routing_metric_t;
 
 #endif /* NET_METRIC_H */

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -135,7 +135,7 @@ static void _send_rreq(aodvv2_packet_data_t *packet_data,
            sizeof(aodvv2_packet_data_t));
 
     _writer_context.type = RFC5444_MSGTYPE_RREQ;
-    _writer_context.packet_data.hoplimit = packet_data->hoplimit;
+    _writer_context.packet_data.msg_hop_limit = packet_data->msg_hop_limit;
 
     /* set address to which the _send_packet callback should send our RREQ */
     memcpy(&_writer_context.target_addr, next_hop, sizeof(ipv6_addr_t));
@@ -159,7 +159,7 @@ static void _send_rrep(aodvv2_packet_data_t *packet_data,
            sizeof(aodvv2_packet_data_t));
 
     _writer_context.type = RFC5444_MSGTYPE_RREP;
-    _writer_context.packet_data.hoplimit = packet_data->hoplimit;
+    _writer_context.packet_data.msg_hop_limit = packet_data->msg_hop_limit;
 
     /* set address to which the _send_packet callback should send our RREQ */
     memcpy(&_writer_context.target_addr, next_hop, sizeof(ipv6_addr_t));
@@ -475,7 +475,7 @@ int aodvv2_find_route(const ipv6_addr_t *orig_addr,
     aodvv2_packet_data_t pkt;
 
     /* Set metric information */
-    pkt.hoplimit = aodvv2_metric_max(METRIC_HOP_COUNT);
+    pkt.msg_hop_limit = aodvv2_metric_max(METRIC_HOP_COUNT);
     pkt.metric_type = CONFIG_AODVV2_DEFAULT_METRIC;
 
     /* Set OrigNode information */

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -65,9 +65,9 @@ void aodvv2_lrs_init(void)
 }
 
 ipv6_addr_t *aodvv2_lrs_get_next_hop(ipv6_addr_t *dest,
-                                     routing_metric_t metricType)
+                                     routing_metric_t metric_type)
 {
-    aodvv2_local_route_t *entry = aodvv2_lrs_get_entry(dest, metricType);
+    aodvv2_local_route_t *entry = aodvv2_lrs_get_entry(dest, metric_type);
     if (!entry) {
         return NULL;
     }
@@ -77,7 +77,7 @@ ipv6_addr_t *aodvv2_lrs_get_next_hop(ipv6_addr_t *dest,
 void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry)
 {
     /* only add if we don't already know the address */
-    if (aodvv2_lrs_get_entry(&entry->addr, entry->metricType)) {
+    if (aodvv2_lrs_get_entry(&entry->addr, entry->metric_type)) {
         return;
     }
     /*find free spot in RT and place rt_entry there */
@@ -91,27 +91,27 @@ void aodvv2_lrs_add_entry(aodvv2_local_route_t *entry)
 }
 
 aodvv2_local_route_t *aodvv2_lrs_get_entry(ipv6_addr_t *addr,
-                                           routing_metric_t metricType)
+                                           routing_metric_t metric_type)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
         _reset_entry_if_stale(i);
 
         if (ipv6_addr_equal(&routing_table[i].route.addr, addr) &&
-            routing_table[i].route.metricType == metricType) {
+            routing_table[i].route.metric_type == metric_type) {
             return &routing_table[i].route;
         }
     }
     return NULL;
 }
 
-void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metricType)
+void aodvv2_lrs_delete_entry(ipv6_addr_t *addr, routing_metric_t metric_type)
 {
     for (unsigned i = 0; i < ARRAY_SIZE(routing_table); i++) {
         _reset_entry_if_stale(i);
 
         if (routing_table[i].used) {
             if (ipv6_addr_equal(&routing_table[i].route.addr, addr) &&
-                routing_table[i].route.metricType == metricType) {
+                routing_table[i].route.metric_type == metric_type) {
                 memset(&routing_table[i].route, 0, sizeof(aodvv2_local_route_t));
                 routing_table[i].used = false;
                 return;
@@ -206,7 +206,7 @@ void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *msg,
     rt_entry->next_hop = msg->sender;
     rt_entry->last_used = msg->timestamp;
     rt_entry->expiration_time = timex_add(msg->timestamp, validity_t);
-    rt_entry->metricType = msg->metric_type;
+    rt_entry->metric_type = msg->metric_type;
     rt_entry->metric = msg->orig_node.metric + link_cost;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }
@@ -221,7 +221,7 @@ void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *msg,
     rt_entry->next_hop = msg->sender;
     rt_entry->last_used = msg->timestamp;
     rt_entry->expiration_time = timex_add(msg->timestamp, validity_t);
-    rt_entry->metricType = msg->metric_type;
+    rt_entry->metric_type = msg->metric_type;
     rt_entry->metric = msg->targ_node.metric + link_cost;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }

--- a/sys/net/aodvv2/aodvv2_lrs.c
+++ b/sys/net/aodvv2/aodvv2_lrs.c
@@ -196,30 +196,32 @@ bool aodvv2_lrs_offers_improvement(aodvv2_local_route_t *rt_entry,
     return true;
 }
 
-void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rreq(aodvv2_packet_data_t *msg,
                                         aodvv2_local_route_t *rt_entry,
                                         uint8_t link_cost)
 {
-    rt_entry->addr = packet_data->orig_node.addr;
-    rt_entry->seqnum = packet_data->orig_node.seqnum;
-    rt_entry->next_hop = packet_data->sender;
-    rt_entry->last_used = packet_data->timestamp;
-    rt_entry->expiration_time = timex_add(packet_data->timestamp, validity_t);
-    rt_entry->metricType = packet_data->metric_type;
-    rt_entry->metric = packet_data->orig_node.metric + link_cost;
+    rt_entry->addr = msg->orig_node.addr;
+    rt_entry->pfx_len = msg->orig_node.pfx_len;
+    rt_entry->seqnum = msg->orig_node.seqnum;
+    rt_entry->next_hop = msg->sender;
+    rt_entry->last_used = msg->timestamp;
+    rt_entry->expiration_time = timex_add(msg->timestamp, validity_t);
+    rt_entry->metricType = msg->metric_type;
+    rt_entry->metric = msg->orig_node.metric + link_cost;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }
 
-void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *packet_data,
+void aodvv2_lrs_fill_routing_entry_rrep(aodvv2_packet_data_t *msg,
                                         aodvv2_local_route_t *rt_entry,
                                         uint8_t link_cost)
 {
-    rt_entry->addr = packet_data->targ_node.addr;
-    rt_entry->seqnum = packet_data->targ_node.seqnum;
-    rt_entry->next_hop = packet_data->sender;
-    rt_entry->last_used = packet_data->timestamp;
-    rt_entry->expiration_time = timex_add(packet_data->timestamp, validity_t);
-    rt_entry->metricType = packet_data->metric_type;
-    rt_entry->metric = packet_data->targ_node.metric + link_cost;
+    rt_entry->addr = msg->targ_node.addr;
+    rt_entry->pfx_len = msg->targ_node.pfx_len;
+    rt_entry->seqnum = msg->targ_node.seqnum;
+    rt_entry->next_hop = msg->sender;
+    rt_entry->last_used = msg->timestamp;
+    rt_entry->expiration_time = timex_add(msg->timestamp, validity_t);
+    rt_entry->metricType = msg->metric_type;
+    rt_entry->metric = msg->targ_node.metric + link_cost;
     rt_entry->state = ROUTE_STATE_ACTIVE;
 }

--- a/sys/net/aodvv2/aodvv2_rcs.c
+++ b/sys/net/aodvv2/aodvv2_rcs.c
@@ -131,7 +131,7 @@ aodvv2_rcs_entry_t *aodvv2_rcs_matches(const ipv6_addr_t *addr,
     return NULL;
 }
 
-bool aodvv2_rcs_is_client(const ipv6_addr_t *addr)
+aodvv2_rcs_entry_t *aodvv2_rcs_is_client(const ipv6_addr_t *addr)
 {
     mutex_lock(&_lock);
     for (unsigned i = 0; i < ARRAY_SIZE(_entries); i++) {
@@ -146,11 +146,11 @@ bool aodvv2_rcs_is_client(const ipv6_addr_t *addr)
         if (ipv6_addr_match_prefix(&entry->data.addr,
                                    addr) >= entry->data.pfx_len) {
             mutex_unlock(&_lock);
-            return true;
+            return &entry->data;
         }
     }
     mutex_unlock(&_lock);
-    return false;
+    return NULL;
 }
 
 void aodvv2_rcs_print_entries(void)

--- a/sys/net/aodvv2/aodvv2_rcs.c
+++ b/sys/net/aodvv2/aodvv2_rcs.c
@@ -54,8 +54,8 @@ aodvv2_rcs_entry_t *aodvv2_rcs_add(const ipv6_addr_t *addr, uint8_t pfx_len,
     }
 
     const aodvv2_rcs_entry_t *entry = aodvv2_rcs_matches(addr, pfx_len);
-    if (entry) {
-        DEBUG_PUTS("aodvv2: client exists, not adding it.\n");
+    if (entry != NULL) {
+        DEBUG_PUTS("aodvv2: client exists, not adding it");
         return NULL;
     }
 
@@ -76,7 +76,7 @@ aodvv2_rcs_entry_t *aodvv2_rcs_add(const ipv6_addr_t *addr, uint8_t pfx_len,
         }
     }
 
-    DEBUG_PUTS("aodvv2: router client set is full.\n");
+    DEBUG_PUTS("aodvv2: router client set is full");
     mutex_unlock(&_lock);
     return NULL;
 }
@@ -120,7 +120,7 @@ aodvv2_rcs_entry_t *aodvv2_rcs_matches(const ipv6_addr_t *addr,
         /* Compare addresses by prefix */
         if ((entry->data.pfx_len == pfx_len) &&
             (ipv6_addr_match_prefix(&entry->data.addr,
-                                   addr) == entry->data.pfx_len)) {
+                                   addr) >= entry->data.pfx_len)) {
             mutex_unlock(&_lock);
             return &entry->data;
         }
@@ -144,7 +144,7 @@ bool aodvv2_rcs_is_client(const ipv6_addr_t *addr)
 
         /* Compare addresses by prefix */
         if (ipv6_addr_match_prefix(&entry->data.addr,
-                                   addr) == entry->data.pfx_len) {
+                                   addr) >= entry->data.pfx_len) {
             mutex_unlock(&_lock);
             return true;
         }
@@ -165,8 +165,8 @@ void aodvv2_rcs_print_entries(void)
             continue;
         }
 
-        /* prints ipv6/prefix - cost */
-        printf("%s/%u - %u",
+        /* prints ipv6/prefix | cost */
+        printf("%s/%u | %u\n",
                ipv6_addr_to_str(buf, &entry->data.addr, sizeof(buf)),
                entry->data.pfx_len, entry->data.cost);
     }

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -121,13 +121,13 @@ static enum rfc5444_result _cb_rrep_blocktlv_messagetlvs_okay(
         return RFC5444_DROP_PACKET;
     }
 
-    _msg_data.hoplimit = cont->hoplimit;
-    if (_msg_data.hoplimit == 0) {
+    _msg_data.msg_hop_limit = cont->hoplimit;
+    if (_msg_data.msg_hop_limit == 0) {
         DEBUG_PUTS("aodvv2: hop limit is 0");
         return RFC5444_DROP_PACKET;
     }
 
-    _msg_data.hoplimit--;
+    _msg_data.msg_hop_limit--;
     return RFC5444_OKAY;
 }
 
@@ -297,12 +297,12 @@ static enum rfc5444_result _cb_rreq_blocktlv_messagetlvs_okay(
         return RFC5444_DROP_PACKET;
     }
 
-    _msg_data.hoplimit = cont->hoplimit;
-    if (_msg_data.hoplimit == 0) {
+    _msg_data.msg_hop_limit = cont->hoplimit;
+    if (_msg_data.msg_hop_limit == 0) {
         DEBUG("aodvv2: Hoplimit is 0.\n");
         return RFC5444_DROP_PACKET;
     }
-    _msg_data.hoplimit--;
+    _msg_data.msg_hop_limit--;
 
     return RFC5444_OKAY;
 }
@@ -396,7 +396,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
         return RFC5444_DROP_PACKET;
     }
 
-    if (_msg_data.hoplimit == 0) {
+    if (_msg_data.msg_hop_limit == 0) {
         DEBUG_PUTS("aodvv2: hop limit is 0");
         return RFC5444_DROP_PACKET;
     }

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -231,7 +231,7 @@ static enum rfc5444_result _cb_rrep_end_callback(
     aodvv2_local_route_t *rt_entry =
         aodvv2_lrs_get_entry(&_msg_data.targ_node.addr, _msg_data.metric_type);
 
-    if (!rt_entry || (rt_entry->metricType != _msg_data.metric_type)) {
+    if (!rt_entry || (rt_entry->metric_type != _msg_data.metric_type)) {
         DEBUG_PUTS("aodvv2: creating new Local Route");
 
         aodvv2_local_route_t tmp = {0};
@@ -431,7 +431,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
         aodvv2_lrs_get_entry(&_msg_data.orig_node.addr,
                              _msg_data.metric_type);
 
-    if (!rt_entry || (rt_entry->metricType != _msg_data.metric_type)) {
+    if (!rt_entry || (rt_entry->metric_type != _msg_data.metric_type)) {
         DEBUG_PUTS("aodvv2: creating new Local Route");
 
         aodvv2_local_route_t tmp = {0};

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -109,7 +109,7 @@ static struct rfc5444_reader_tlvblock_consumer_entry _address_consumer_entries[]
 };
 
 static struct netaddr_str nbuf;
-static aodvv2_packet_data_t packet_data;
+static aodvv2_packet_data_t _msg_data;
 
 static kernel_pid_t _netif_pid = KERNEL_PID_UNDEF;
 
@@ -117,17 +117,17 @@ static enum rfc5444_result _cb_rrep_blocktlv_messagetlvs_okay(
         struct rfc5444_reader_tlvblock_context *cont)
 {
     if (!cont->has_hoplimit) {
-        DEBUG("rfc5444_reader: missing hop limit\n");
+        DEBUG_PUTS("aodvv2: missing hop limit");
         return RFC5444_DROP_PACKET;
     }
 
-    packet_data.hoplimit = cont->hoplimit;
-    if (packet_data.hoplimit == 0) {
-        DEBUG("rfc5444_reader: hop limit is 0.\n");
+    _msg_data.hoplimit = cont->hoplimit;
+    if (_msg_data.hoplimit == 0) {
+        DEBUG_PUTS("aodvv2: hop limit is 0");
         return RFC5444_DROP_PACKET;
     }
 
-    packet_data.hoplimit--;
+    _msg_data.hoplimit--;
     return RFC5444_OKAY;
 }
 
@@ -137,50 +137,50 @@ static enum rfc5444_result _cb_rrep_blocktlv_addresstlvs_okay(
     struct rfc5444_reader_tlvblock_entry *tlv;
     bool is_targ_node_addr = false;
 
-    DEBUG("rfc5444_reader: %s\n", netaddr_to_string(&nbuf, &cont->addr));
+    DEBUG("aodvv2: %s\n", netaddr_to_string(&nbuf, &cont->addr));
 
     /* handle TargNode SeqNum TLV */
     tlv = _address_consumer_entries[RFC5444_MSGTLV_TARGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_TARGSEQNUM: %d\n",
-              *tlv->single_value);
+        DEBUG("aodvv2: RFC5444_MSGTLV_TARGSEQNUM: %d\n", *tlv->single_value);
         is_targ_node_addr = true;
-        netaddr_to_ipv6_addr(&cont->addr, &packet_data.targ_node.addr);
-        packet_data.targ_node.seqnum = *tlv->single_value;
+        netaddr_to_ipv6_addr(&cont->addr, &_msg_data.targ_node.addr,
+                             &_msg_data.targ_node.pfx_len);
+        _msg_data.targ_node.seqnum = *tlv->single_value;
     }
 
     /* handle OrigNode SeqNum TLV */
     tlv = _address_consumer_entries[RFC5444_MSGTLV_ORIGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_ORIGSEQNUM: %d\n",
-              *tlv->single_value);
+        DEBUG("aodvv2: RFC5444_MSGTLV_ORIGSEQNUM: %d\n", *tlv->single_value);
         is_targ_node_addr = false;
-        netaddr_to_ipv6_addr(&cont->addr, &packet_data.orig_node.addr);
-        packet_data.orig_node.seqnum = *tlv->single_value;
+        netaddr_to_ipv6_addr(&cont->addr, &_msg_data.orig_node.addr,
+                             &_msg_data.targ_node.pfx_len);
+        _msg_data.orig_node.seqnum = *tlv->single_value;
     }
 
     if (!tlv && !is_targ_node_addr) {
-        DEBUG("rfc5444_reader: mandatory SeqNum TLV missing!\n");
+        DEBUG_PUTS("aodvv2: mandatory SeqNum TLV missing!");
         return RFC5444_DROP_PACKET;
     }
 
     tlv = _address_consumer_entries[RFC5444_MSGTLV_METRIC].tlv;
     if (!tlv && is_targ_node_addr) {
-        DEBUG("rfc5444_reader: missing or unknown metric TLV!\n");
+        DEBUG_PUTS("aodvv2: missing or unknown metric TLV!");
         return RFC5444_DROP_PACKET;
     }
 
     if (tlv) {
         if (!is_targ_node_addr) {
-            DEBUG("rfc5444_reader: metric TLV belongs to wrong address!\n");
+            DEBUG_PUTS("aodvv2: metric TLV belongs to wrong address!");
             return RFC5444_DROP_PACKET;
         }
 
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
-               *tlv->single_value, tlv->type_ext);
+        DEBUG("aodvv2: RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
+              *tlv->single_value, tlv->type_ext);
 
-        packet_data.metric_type = tlv->type_ext;
-        packet_data.orig_node.metric = *tlv->single_value;
+        _msg_data.metric_type = tlv->type_ext;
+        _msg_data.orig_node.metric = *tlv->single_value;
     }
 
     return RFC5444_OKAY;
@@ -193,110 +193,98 @@ static enum rfc5444_result _cb_rrep_end_callback(
 
     /* Check if packet contains the required information */
     if (dropped) {
-        DEBUG("rfc5444_reader: dropping packet.\n");
+        DEBUG_PUTS("aodvv2: dropping packet");
         return RFC5444_DROP_PACKET;
     }
 
-    if (ipv6_addr_is_unspecified(&packet_data.orig_node.addr) ||
-        !packet_data.orig_node.seqnum) {
-        DEBUG("rfc5444_reader: missing OrigNode Address or SeqNum!\n");
+    if (ipv6_addr_is_unspecified(&_msg_data.orig_node.addr) ||
+        _msg_data.orig_node.seqnum == 0) {
+        DEBUG_PUTS("aodvv2: missing OrigNode Address or SeqNum");
         return RFC5444_DROP_PACKET;
     }
 
-    if (ipv6_addr_is_unspecified(&packet_data.targ_node.addr) ||
-        !packet_data.targ_node.seqnum) {
-        DEBUG("rfc5444_reader: missing TargNode Address or SeqNum!\n");
+    if (ipv6_addr_is_unspecified(&_msg_data.targ_node.addr) ||
+        _msg_data.targ_node.seqnum == 0) {
+        DEBUG_PUTS("aodvv2: missing TargNode Address or SeqNum");
         return RFC5444_DROP_PACKET;
     }
 
-    uint8_t link_cost = aodvv2_metric_link_cost(packet_data.metric_type);
+    uint8_t link_cost = aodvv2_metric_link_cost(_msg_data.metric_type);
 
-    if ((aodvv2_metric_max(packet_data.metric_type) - link_cost) <=
-        packet_data.targ_node.metric) {
-        DEBUG("rfc5444_reader: metric Limit reached!\n");
+    if ((aodvv2_metric_max(_msg_data.metric_type) - link_cost) <=
+        _msg_data.targ_node.metric) {
+        DEBUG_PUTS("aodvv2: metric limit reached");
         return RFC5444_DROP_PACKET;
     }
 
-    aodvv2_metric_update(packet_data.metric_type,
-                         &packet_data.targ_node.metric);
+    aodvv2_metric_update(_msg_data.metric_type, &_msg_data.targ_node.metric);
 
     /* Update packet timestamp */
     timex_t now;
     xtimer_now_timex(&now);
-    packet_data.timestamp = now;
+    _msg_data.timestamp = now;
 
     /* for every relevant address (RteMsg.Addr) in the RteMsg, HandlingRtr
     searches its route table to see if there is a route table entry with the
     same MetricType of the RteMsg, matching RteMsg.Addr. */
 
     aodvv2_local_route_t *rt_entry =
-        aodvv2_lrs_get_entry(&packet_data.targ_node.addr,
-                             packet_data.metric_type);
+        aodvv2_lrs_get_entry(&_msg_data.targ_node.addr, _msg_data.metric_type);
 
-    if (!rt_entry || (rt_entry->metricType != packet_data.metric_type)) {
-        DEBUG("rfc5444_reader: creating new Routing Table entry...\n");
+    if (!rt_entry || (rt_entry->metricType != _msg_data.metric_type)) {
+        DEBUG_PUTS("aodvv2: creating new Local Route");
 
         aodvv2_local_route_t tmp = {0};
-        aodvv2_lrs_fill_routing_entry_rrep(&packet_data, &tmp, link_cost);
+        aodvv2_lrs_fill_routing_entry_rrep(&_msg_data, &tmp, link_cost);
         aodvv2_lrs_add_entry(&tmp);
 
-        /* Add entry to nib forwading table */
-        ipv6_addr_t *dst = &packet_data.targ_node.addr;
-        ipv6_addr_t *next_hop = &packet_data.sender;
-
-        DEBUG("rfc5444_reader: adding route to NIB FT\n");
-        if (gnrc_ipv6_nib_ft_add(dst, AODVV2_PREFIX_LEN, next_hop,
+        /* Add entry to NIB forwading table */
+        DEBUG_PUTS("aodvv2: adding Local Route to NIB FT");
+        if (gnrc_ipv6_nib_ft_add(&_msg_data.targ_node.addr,
+                                 _msg_data.targ_node.pfx_len, &_msg_data.sender,
                                  _netif_pid, AODVV2_ROUTE_LIFETIME) < 0) {
-            DEBUG("rfc5444_reader: couldn't add route!\n");
+            DEBUG_PUTS("aodvv2: couldn't add route");
         }
     }
     else {
-        if (!aodvv2_lrs_offers_improvement(rt_entry, &packet_data.targ_node)) {
-            DEBUG("rfc5444_reader: RREP offers no improvement over known route.\n");
+        if (!aodvv2_lrs_offers_improvement(rt_entry, &_msg_data.targ_node)) {
+            DEBUG_PUTS("aodvv2: RREP offers no improvement over known route");
             return RFC5444_DROP_PACKET;
         }
 
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
-        DEBUG("rfc5444_reader: updating Routing Table entry...\n");
-        aodvv2_lrs_fill_routing_entry_rrep(&packet_data, rt_entry, link_cost);
+        DEBUG_PUTS("aodvv2: updating Routing Table entry");
+        aodvv2_lrs_fill_routing_entry_rrep(&_msg_data, rt_entry, link_cost);
 
         /* Add entry to nib forwading table */
-        ipv6_addr_t *dst = &rt_entry->addr;
-        ipv6_addr_t *next_hop = &rt_entry->next_hop;
+        gnrc_ipv6_nib_ft_del(&rt_entry->addr, rt_entry->pfx_len);
 
-        gnrc_ipv6_nib_ft_del(dst, AODVV2_PREFIX_LEN);
-
-        DEBUG("rfc5444_reader: adding route to NIB FT\n");
-        if (gnrc_ipv6_nib_ft_add(dst, AODVV2_PREFIX_LEN, next_hop,
-                                 _netif_pid, AODVV2_ROUTE_LIFETIME) < 0) {
-            DEBUG("rfc5444_reader: couldn't add route!\n");
+        DEBUG_PUTS("aodvv2: adding route to NIB FT");
+        if (gnrc_ipv6_nib_ft_add(&rt_entry->addr, rt_entry->pfx_len,
+                                 &rt_entry->next_hop, _netif_pid,
+                                 AODVV2_ROUTE_LIFETIME) < 0) {
+            DEBUG_PUTS("aodvv2: couldn't add route");
         }
     }
 
-    /* If HandlingRtr is RREQ_Gen then the RREP satisfies RREQ_Gen's earlier
-     * RREQ, and RREP processing is completed. Any packets buffered for
-     * OrigNode should be transmitted. */
-    if (aodvv2_rcs_is_client(&packet_data.orig_node.addr)) {
-        DEBUG("rfc5444_reader: {%" PRIu32 ":%" PRIu32 "}\n",
+    if (aodvv2_rcs_is_client(&_msg_data.orig_node.addr)) {
+        DEBUG("aodvv2: {%" PRIu32 ":%" PRIu32 "}\n",
               now.seconds, now.microseconds);
-        DEBUG("rfc5444_reader: this is my RREP (SeqNum: %d)\n",
-              packet_data.orig_node.seqnum);
-        DEBUG("rfc5444_reader: We are done here, thanks!\n");
+        DEBUG("aodvv2: this is my RREP (SeqNum: %d)\n",
+              _msg_data.orig_node.seqnum);
+        DEBUG_PUTS("aodvv2: We are done here, thanks!");
 
         /* Send buffered packets for this address */
-        aodvv2_buffer_dispatch(&packet_data.targ_node.addr);
+        aodvv2_buffer_dispatch(&_msg_data.targ_node.addr);
     }
     else {
-        /* If HandlingRtr is not RREQ_Gen then the outgoing RREP is sent to the
-         * Route.NextHopAddress for the RREP.AddrBlk[OrigNodeNdx]. */
-        DEBUG("rfc5444_reader: not my RREP\n");
-        DEBUG("rfc5444_reader: passing it on to the next hop\n");
+        DEBUG_PUTS("aodvv2: not my RREP, passing it on to the next hop.");
 
         ipv6_addr_t *next_hop =
-            aodvv2_lrs_get_next_hop(&packet_data.orig_node.addr,
-                                    packet_data.metric_type);
-        aodvv2_send_rrep(&packet_data, next_hop);
+            aodvv2_lrs_get_next_hop(&_msg_data.orig_node.addr,
+                                    _msg_data.metric_type);
+        aodvv2_send_rrep(&_msg_data, next_hop);
     }
     return RFC5444_OKAY;
 }
@@ -305,16 +293,17 @@ static enum rfc5444_result _cb_rreq_blocktlv_messagetlvs_okay(
         struct rfc5444_reader_tlvblock_context *cont)
 {
     if (!cont->has_hoplimit) {
-        DEBUG("rfc5444_reader: missing hop limit\n");
+        DEBUG("aodvv2: missing hop limit\n");
         return RFC5444_DROP_PACKET;
     }
 
-    packet_data.hoplimit = cont->hoplimit;
-    if (packet_data.hoplimit == 0) {
-        DEBUG("rfc5444_reader: Hoplimit is 0.\n");
+    _msg_data.hoplimit = cont->hoplimit;
+    if (_msg_data.hoplimit == 0) {
+        DEBUG("aodvv2: Hoplimit is 0.\n");
         return RFC5444_DROP_PACKET;
     }
-    packet_data.hoplimit--;
+    _msg_data.hoplimit--;
+
     return RFC5444_OKAY;
 }
 
@@ -325,38 +314,38 @@ static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(
     bool is_orig_node_addr = false;
     bool is_targ_node = false;
 
-    DEBUG("rfc5444_reader: %s\n", netaddr_to_string(&nbuf, &cont->addr));
+    DEBUG("aodvv2: %s\n", netaddr_to_string(&nbuf, &cont->addr));
 
     /* handle OrigNode SeqNum TLV */
     tlv = _address_consumer_entries[RFC5444_MSGTLV_ORIGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_ORIGSEQNUM: %d\n",
-              *tlv->single_value);
-
+        DEBUG("aodvv2: RFC5444_MSGTLV_ORIGSEQNUM: %d\n", *tlv->single_value);
         is_orig_node_addr = true;
-        netaddr_to_ipv6_addr(&cont->addr, &packet_data.orig_node.addr);
-        packet_data.orig_node.seqnum = *tlv->single_value;
+        netaddr_to_ipv6_addr(&cont->addr, &_msg_data.orig_node.addr,
+                             &_msg_data.orig_node.pfx_len);
+        _msg_data.orig_node.seqnum = *tlv->single_value;
     }
 
     /* handle TargNode SeqNum TLV */
     tlv = _address_consumer_entries[RFC5444_MSGTLV_TARGSEQNUM].tlv;
     if (tlv) {
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_TARGSEQNUM: %d\n",
-              *tlv->single_value);
+        DEBUG("aodvv2: RFC5444_MSGTLV_TARGSEQNUM: %d\n", *tlv->single_value);
 
         is_targ_node = true;
-        netaddr_to_ipv6_addr(&cont->addr, &packet_data.targ_node.addr);
-        packet_data.targ_node.seqnum = *tlv->single_value;
+        netaddr_to_ipv6_addr(&cont->addr, &_msg_data.targ_node.addr,
+                             &_msg_data.targ_node.pfx_len);
+        _msg_data.targ_node.seqnum = *tlv->single_value;
     }
 
     if (!tlv && !is_orig_node_addr) {
         /* assume that tlv missing => targ_node Address */
         is_targ_node = true;
-        netaddr_to_ipv6_addr(&cont->addr, &packet_data.targ_node.addr);
+        netaddr_to_ipv6_addr(&cont->addr, &_msg_data.targ_node.addr,
+                             &_msg_data.targ_node.pfx_len);
     }
 
     if (!is_orig_node_addr && !is_targ_node) {
-        DEBUG("rfc5444_reader: mandatory RFC5444_MSGTLV_ORIGSEQNUM TLV missing!\n");
+        DEBUG_PUTS("aodvv2: mandatory RFC5444_MSGTLV_ORIGSEQNUM TLV missing");
         return RFC5444_DROP_PACKET;
     }
 
@@ -366,19 +355,20 @@ static enum rfc5444_result _cb_rreq_blocktlv_addresstlvs_okay(
     /* cppcheck-suppress arrayIndexOutOfBounds */
     tlv = _address_consumer_entries[RFC5444_MSGTLV_METRIC].tlv;
     if (!tlv && is_orig_node_addr) {
-        DEBUG("rfc5444_reader: Missing or unknown metric TLV.\n");
+        DEBUG_PUTS("aodvv2: missing or unknown metric TLV");
         return RFC5444_DROP_PACKET;
     }
 
     if (tlv) {
         if (!is_orig_node_addr) {
-            DEBUG("rfc5444_reader: Metric TLV belongs to wrong address.\n");
+            DEBUG_PUTS("aodvv2: metric TLV belongs to wrong address");
             return RFC5444_DROP_PACKET;
         }
-        DEBUG("rfc5444_reader: RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
+        DEBUG("aodvv2: RFC5444_MSGTLV_METRIC val: %d, exttype: %d\n",
                *tlv->single_value, tlv->type_ext);
-        packet_data.metric_type = tlv->type_ext;
-        packet_data.orig_node.metric = *tlv->single_value;
+
+        _msg_data.metric_type = tlv->type_ext;
+        _msg_data.orig_node.metric = *tlv->single_value;
     }
     return RFC5444_OKAY;
 }
@@ -391,95 +381,94 @@ static enum rfc5444_result _cb_rreq_end_callback(
 
     /* Check if packet contains the required information */
     if (dropped) {
-        DEBUG("rfc5444_reader: dropping packet.\n");
-        return RFC5444_DROP_PACKET;
-    }
-    if (ipv6_addr_is_unspecified(&packet_data.orig_node.addr) ||
-        !packet_data.orig_node.seqnum) {
-        DEBUG("rfc5444_reader: missing OrigNode Address or SeqNum!\n");
-        return RFC5444_DROP_PACKET;
-    }
-    if (ipv6_addr_is_unspecified(&packet_data.targ_node.addr)) {
-        DEBUG("rfc5444_reader: missing TargNode Address!\n");
-        return RFC5444_DROP_PACKET;
-    }
-    if (packet_data.hoplimit == 0) {
-        DEBUG("rfc5444_reader: hop limit is 0!\n");
+        DEBUG_PUTS("aodvv2: dropping packet");
         return RFC5444_DROP_PACKET;
     }
 
-    uint8_t link_cost = aodvv2_metric_link_cost(packet_data.metric_type);
-    if ((aodvv2_metric_max(packet_data.metric_type) - link_cost) <=
-        packet_data.orig_node.metric) {
-        DEBUG("rfc5444_reader: metric limit reached!\n");
+    if (ipv6_addr_is_unspecified(&_msg_data.orig_node.addr) ||
+        _msg_data.orig_node.seqnum == 0) {
+        DEBUG_PUTS("aodvv2: missing OrigNode Address or SeqNum");
+        return RFC5444_DROP_PACKET;
+    }
+
+    if (ipv6_addr_is_unspecified(&_msg_data.targ_node.addr)) {
+        DEBUG_PUTS("aodvv2: missing TargNode Address");
+        return RFC5444_DROP_PACKET;
+    }
+
+    if (_msg_data.hoplimit == 0) {
+        DEBUG_PUTS("aodvv2: hop limit is 0");
+        return RFC5444_DROP_PACKET;
+    }
+
+    uint8_t link_cost = aodvv2_metric_link_cost(_msg_data.metric_type);
+    if ((aodvv2_metric_max(_msg_data.metric_type) - link_cost) <=
+        _msg_data.orig_node.metric) {
+        DEBUG_PUTS("aodvv2: metric limit reached");
         return RFC5444_DROP_PACKET;
     }
 
     /* The incoming RREQ MUST be checked against previously received information
      * from the RREQ Table Section 7.6.  If the information in the incoming
      * RteMsg is redundant, then then no further action is taken. */
-    if (aodvv2_rreqtable_is_redundant(&packet_data)) {
-        DEBUG("rfc5444_reader: packet is redundant!\n");
+    if (aodvv2_rreqtable_is_redundant(&_msg_data)) {
+        DEBUG_PUTS("aodvv2: packet is redundant");
         return RFC5444_DROP_PACKET;
     }
 
-    aodvv2_metric_update(packet_data.metric_type, &packet_data.orig_node.metric);
+    aodvv2_metric_update(_msg_data.metric_type, &_msg_data.orig_node.metric);
 
     /* Update packet timestamp */
     timex_t now;
     xtimer_now_timex(&now);
-    packet_data.timestamp = now;
+    _msg_data.timestamp = now;
 
     /* For every relevant address (RteMsg.Addr) in the RteMsg, HandlingRtr
      * searches its route table to see if there is a route table entry with the
      * same MetricType of the RteMsg, matching RteMsg.Addr.
      */
     aodvv2_local_route_t *rt_entry =
-        aodvv2_lrs_get_entry(&packet_data.orig_node.addr,
-                             packet_data.metric_type);
+        aodvv2_lrs_get_entry(&_msg_data.orig_node.addr,
+                             _msg_data.metric_type);
 
-    if (!rt_entry || (rt_entry->metricType != packet_data.metric_type)) {
-        DEBUG("rfc5444_reader: creating new Routing Table entry...\n");
+    if (!rt_entry || (rt_entry->metricType != _msg_data.metric_type)) {
+        DEBUG_PUTS("aodvv2: creating new Local Route");
 
         aodvv2_local_route_t tmp = {0};
 
-        /* Add this RREQ to routing table*/
-        aodvv2_lrs_fill_routing_entry_rreq(&packet_data, &tmp, link_cost);
+        /* Add this RREQ to LRS */
+        aodvv2_lrs_fill_routing_entry_rreq(&_msg_data, &tmp, link_cost);
         aodvv2_lrs_add_entry(&tmp);
 
-        /* Add entry to nib forwading table */
-        ipv6_addr_t *dst = &packet_data.orig_node.addr;
-        ipv6_addr_t *next_hop = &packet_data.sender;
-
-        DEBUG("rfc5444_reader: adding route to NIB FT\n");
-        if (gnrc_ipv6_nib_ft_add(dst, AODVV2_PREFIX_LEN, next_hop,
+        /* Add entry to NIB forwading table */
+        DEBUG_PUTS("aodvv2: adding route to NIB FT");
+        if (gnrc_ipv6_nib_ft_add(&_msg_data.orig_node.addr,
+                                 _msg_data.orig_node.pfx_len, &_msg_data.sender,
                                  _netif_pid, AODVV2_ROUTE_LIFETIME) < 0) {
-            DEBUG("rfc5444_reader: couldn't add route!\n");
+            DEBUG_PUTS("aodvv2: couldn't add route");
         }
     }
     else {
         /* If the route is aready stored verify if this route offers an
          * improvement in path*/
-        if (!aodvv2_lrs_offers_improvement(rt_entry, &packet_data.orig_node)) {
-            DEBUG("rfc5444_reader: packet offers no improvement over known route.\n");
+        if (!aodvv2_lrs_offers_improvement(rt_entry, &_msg_data.orig_node)) {
+            DEBUG_PUTS("aodvv2: packet offers no improvement over known route");
             return RFC5444_DROP_PACKET;
         }
 
         /* The incoming routing information is better than existing routing
          * table information and SHOULD be used to improve the route table. */
-        DEBUG("rfc5444_reader: updating Routing Table entry...\n");
-        aodvv2_lrs_fill_routing_entry_rreq(&packet_data, rt_entry, link_cost);
+        DEBUG_PUTS("aodvv2: updating Local Route");
+        aodvv2_lrs_fill_routing_entry_rreq(&_msg_data, rt_entry, link_cost);
 
         /* Add entry to nib forwading table */
-        ipv6_addr_t *dst = &rt_entry->addr;
-        ipv6_addr_t *next_hop = &rt_entry->next_hop;
+        gnrc_ipv6_nib_ft_del(&rt_entry->addr, rt_entry->pfx_len);
 
-        gnrc_ipv6_nib_ft_del(dst, AODVV2_PREFIX_LEN);
-
-        DEBUG("rfc5444_reader: adding route to NIB FT\n");
-        if (gnrc_ipv6_nib_ft_add(dst, AODVV2_PREFIX_LEN, next_hop,
-                                 _netif_pid, AODVV2_ROUTE_LIFETIME) < 0) {
-            DEBUG("rfc5444_reader: couldn't add route!\n");
+        DEBUG_PUTS("aodvv2: adding route to NIB FT");
+        if (gnrc_ipv6_nib_ft_add(&rt_entry->addr, rt_entry->pfx_len,
+                                 &rt_entry->next_hop, _netif_pid,
+                                 AODVV2_ROUTE_LIFETIME) < 0) {
+            DEBUG_PUTS("aodvv2: couldn't add route");
         }
     }
 
@@ -488,17 +477,17 @@ static enum rfc5444_result _cb_rreq_end_callback(
      * subsequently processing for the RREQ is complete.  Otherwise,
      * processing continues as follows.
      */
-    if (aodvv2_rcs_is_client(&packet_data.targ_node.addr)) {
-        DEBUG("rfc5444_reader: targ_node is in client list, sending RREP\n");
+    if (aodvv2_rcs_is_client(&_msg_data.targ_node.addr)) {
+        DEBUG_PUTS("aodvv2: TargNode is on client list, sending RREP");
 
         /* Make sure to start with a clean metric value */
-        packet_data.targ_node.metric = 0;
+        _msg_data.targ_node.metric = 0;
 
-        aodvv2_send_rrep(&packet_data, &packet_data.sender);
+        aodvv2_send_rrep(&_msg_data, &_msg_data.sender);
     }
     else {
-        DEBUG("rfc5444_reader: i'm not targ_node, forwarding RREQ\n");
-        aodvv2_send_rreq(&packet_data, &ipv6_addr_all_manet_routers_link_local);
+        DEBUG_PUTS("aodvv2: I'm not TargNode, forwarding RREQ");
+        aodvv2_send_rreq(&_msg_data, &ipv6_addr_all_manet_routers_link_local);
     }
 
     return RFC5444_OKAY;
@@ -532,5 +521,5 @@ void aodvv2_rfc5444_handle_packet_prepare(ipv6_addr_t *sender)
 {
     assert(sender != NULL);
 
-    packet_data.sender = *sender;
+    _msg_data.sender = *sender;
 }

--- a/sys/net/aodvv2/rfc5444_reader.c
+++ b/sys/net/aodvv2/rfc5444_reader.c
@@ -268,7 +268,7 @@ static enum rfc5444_result _cb_rrep_end_callback(
         }
     }
 
-    if (aodvv2_rcs_is_client(&_msg_data.orig_node.addr)) {
+    if (aodvv2_rcs_is_client(&_msg_data.orig_node.addr) != NULL) {
         DEBUG("aodvv2: {%" PRIu32 ":%" PRIu32 "}\n",
               now.seconds, now.microseconds);
         DEBUG("aodvv2: this is my RREP (SeqNum: %d)\n",
@@ -477,7 +477,7 @@ static enum rfc5444_result _cb_rreq_end_callback(
      * subsequently processing for the RREQ is complete.  Otherwise,
      * processing continues as follows.
      */
-    if (aodvv2_rcs_is_client(&_msg_data.targ_node.addr)) {
+    if (aodvv2_rcs_is_client(&_msg_data.targ_node.addr) != NULL) {
         DEBUG_PUTS("aodvv2: TargNode is on client list, sending RREP");
 
         /* Make sure to start with a clean metric value */

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -81,9 +81,9 @@ static aodvv2_writer_target_t *_target;
 static void _cb_add_message_header(struct rfc5444_writer *wr,
                                    struct rfc5444_writer_message *message)
 {
-    /* no originator, no hopcount, has hoplimit, no seqno */
+    /* no originator, no hopcount, has msg_hop_limit, no seqno */
     rfc5444_writer_set_msg_header(wr, message, false, false, true, false);
-    rfc5444_writer_set_msg_hoplimit(wr, message, _target->packet_data.hoplimit);
+    rfc5444_writer_set_msg_hoplimit(wr, message, _target->packet_data.msg_hop_limit);
 }
 
 static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -92,7 +92,8 @@ static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)
     struct netaddr tmp;
 
     /* add orig_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, &tmp);
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr,
+                         _target->packet_data.orig_node.pfx_len, &tmp);
     orig_node_addr =
         rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
                                    &tmp, true);
@@ -100,7 +101,9 @@ static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)
     assert(orig_node_addr != NULL);
 
     /* add targ_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, &tmp);
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr,
+                         _target->packet_data.targ_node.pfx_len,
+                         &tmp);
     rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
                                &tmp, true);
 
@@ -130,7 +133,8 @@ static void _cb_rrep_add_addresses(struct rfc5444_writer *wr)
     uint8_t targ_node_hopct = _target->packet_data.targ_node.metric;
 
     /* add orig_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, &tmp);
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr,
+                         _target->packet_data.orig_node.pfx_len, &tmp);
     orig_node_addr =
         rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
                                    &tmp, true);
@@ -138,7 +142,8 @@ static void _cb_rrep_add_addresses(struct rfc5444_writer *wr)
     assert(orig_node_addr != NULL);
 
     /* add targ_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, &tmp);
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr,
+                         _target->packet_data.targ_node.pfx_len, &tmp);
     targ_node_addr =
         rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
                                    &tmp, true);

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -88,126 +88,108 @@ static void _cb_add_message_header(struct rfc5444_writer *wr,
 
 static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)
 {
-    struct rfc5444_writer_address *orig_node_addr;
+    struct rfc5444_writer_address *orig_prefix;
     struct netaddr tmp;
+    uint8_t pfx_len;
 
-    /* add orig_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr,
-                         _target->packet_data.orig_node.pfx_len, &tmp);
-    orig_node_addr =
-        rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
-                                   &tmp, true);
+    /* Add OrigPrefix address */
+    pfx_len = _target->packet_data.orig_node.pfx_len;
+    if (pfx_len == 0 || pfx_len > 128) {
+        pfx_len = 128;
+    }
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, pfx_len, &tmp);
+    orig_prefix = rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator, &tmp, true);
+    assert(orig_prefix != NULL);
 
-    assert(orig_node_addr != NULL);
+    /* Add TargPrefix address */
+    pfx_len = _target->packet_data.targ_node.pfx_len;
+    if (pfx_len == 0 || pfx_len > 128) {
+        pfx_len = 128;
+    }
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, pfx_len, &tmp);
+    rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator, &tmp, true);
 
-    /* add targ_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr,
-                         _target->packet_data.targ_node.pfx_len,
-                         &tmp);
-    rfc5444_writer_add_address(wr, _rreq_message_content_provider.creator,
-                               &tmp, true);
-
-    /* add SeqNum TLV and metric TLV to OrigNode */
-    rfc5444_writer_add_addrtlv(wr, orig_node_addr,
-                               &_rreq_addrtlvs[RFC5444_MSGTLV_ORIGSEQNUM],
-                               &_target->packet_data.orig_node.seqnum,
-                               sizeof(_target->packet_data.orig_node.seqnum),
+    /* Add SeqNum TLV and metric TLV to OrigPrefix */
+    rfc5444_writer_add_addrtlv(wr, orig_prefix, &_rreq_addrtlvs[RFC5444_MSGTLV_ORIGSEQNUM],
+                               &_target->packet_data.orig_node.seqnum, sizeof(_target->packet_data.orig_node.seqnum),
                                false);
 
-    rfc5444_writer_add_addrtlv(wr, orig_node_addr,
-                               &_rreq_addrtlvs[RFC5444_MSGTLV_METRIC],
-                               &_target->packet_data.orig_node.metric,
-                               sizeof(_target->packet_data.orig_node.metric),
+    rfc5444_writer_add_addrtlv(wr, orig_prefix, &_rreq_addrtlvs[RFC5444_MSGTLV_METRIC],
+                               &_target->packet_data.orig_node.metric, sizeof(_target->packet_data.orig_node.metric),
                                false);
 }
 
 static void _cb_rrep_add_addresses(struct rfc5444_writer *wr)
 {
-    struct rfc5444_writer_address *orig_node_addr;
-    struct rfc5444_writer_address *targ_node_addr;
+    struct rfc5444_writer_address *orig_prefix;
+    struct rfc5444_writer_address *targ_prefix;
     struct netaddr tmp;
+    uint8_t pfx_len;
 
     uint16_t orig_node_seqnum = _target->packet_data.orig_node.seqnum;
     uint16_t targ_node_seqnum = aodvv2_seqnum_get();
     aodvv2_seqnum_inc();
     uint8_t targ_node_hopct = _target->packet_data.targ_node.metric;
 
-    /* add orig_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr,
-                         _target->packet_data.orig_node.pfx_len, &tmp);
-    orig_node_addr =
-        rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
-                                   &tmp, true);
+    /* Add OrigPrefix address */
+    pfx_len = _target->packet_data.orig_node.pfx_len;
+    if (pfx_len == 0 || pfx_len > 128) {
+        pfx_len = 128;
+    }
+    ipv6_addr_to_netaddr(&_target->packet_data.orig_node.addr, pfx_len, &tmp);
+    orig_prefix = rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator, &tmp, true);
+    assert(orig_prefix != NULL);
 
-    assert(orig_node_addr != NULL);
+    /* Add TargPrefix address */
+    pfx_len = _target->packet_data.targ_node.pfx_len;
+    if (pfx_len == 0 || pfx_len > 128) {
+        pfx_len = 128;
+    }
+    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr, pfx_len, &tmp);
+    targ_prefix = rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator, &tmp, true);
+    assert(orig_prefix != NULL);
 
-    /* add targ_node address (has no address tlv); is mandatory address */
-    ipv6_addr_to_netaddr(&_target->packet_data.targ_node.addr,
-                         _target->packet_data.targ_node.pfx_len, &tmp);
-    targ_node_addr =
-        rfc5444_writer_add_address(wr, _rrep_message_content_provider.creator,
-                                   &tmp, true);
+    /* Add ORIGSEQNUM TLV to OrigPrefix */
+    rfc5444_writer_add_addrtlv(wr, orig_prefix, &_rrep_addrtlvs[RFC5444_MSGTLV_ORIGSEQNUM], &orig_node_seqnum,
+                               sizeof(orig_node_seqnum), false);
 
-    assert(targ_node_addr != NULL);
+    /* Add ORIGSEQNUM and METRIC TLV to TargPrefix */
+    rfc5444_writer_add_addrtlv(wr, targ_prefix, &_rrep_addrtlvs[RFC5444_MSGTLV_TARGSEQNUM], &targ_node_seqnum,
+                               sizeof(targ_node_seqnum), false);
 
-    /* add OrigNode and TargNode SeqNum TLVs */
-    rfc5444_writer_add_addrtlv(wr, orig_node_addr,
-                               &_rrep_addrtlvs[RFC5444_MSGTLV_ORIGSEQNUM],
-                               &orig_node_seqnum, sizeof(orig_node_seqnum),
-                               false);
-
-    rfc5444_writer_add_addrtlv(wr, targ_node_addr,
-                               &_rrep_addrtlvs[RFC5444_MSGTLV_TARGSEQNUM],
-                               &targ_node_seqnum, sizeof(targ_node_seqnum),
-                               false);
-
-    /* Add Metric TLV to targ_node Address */
-    rfc5444_writer_add_addrtlv(wr, targ_node_addr,
-                               &_rrep_addrtlvs[RFC5444_MSGTLV_METRIC],
-                               &targ_node_hopct, sizeof(targ_node_hopct),
-                               false);
-
-    assert(res == RFC5444_OKAY);
+    rfc5444_writer_add_addrtlv(wr, targ_prefix, &_rrep_addrtlvs[RFC5444_MSGTLV_METRIC], &targ_node_hopct,
+                               sizeof(targ_node_hopct), false);
 }
 
-void aodvv2_rfc5444_writer_register(struct rfc5444_writer *writer,
-                                    aodvv2_writer_target_t *target)
+void aodvv2_rfc5444_writer_register(struct rfc5444_writer *wr, aodvv2_writer_target_t *target)
 {
-    int res;
+    assert(wr != NULL && target != NULL);
 
-    assert(writer != NULL && target != NULL);
+    int res;
 
     _target = target;
 
-    res =
-        rfc5444_writer_register_msgcontentprovider(writer,
-                                                   &_rreq_message_content_provider,
-                                                   _rreq_addrtlvs,
-                                                   ARRAY_SIZE(_rreq_addrtlvs));
+    res = rfc5444_writer_register_msgcontentprovider(wr, &_rreq_message_content_provider, _rreq_addrtlvs,
+                                                     ARRAY_SIZE(_rreq_addrtlvs));
     if (res < 0) {
         DEBUG("rfc5444_writer: couldn't reigster RREQ message provider\n");
         return;
     }
 
-    res =
-        rfc5444_writer_register_msgcontentprovider(writer,
-                                                   &_rrep_message_content_provider,
-                                                   _rrep_addrtlvs,
-                                                   ARRAY_SIZE(_rrep_addrtlvs));
+    res = rfc5444_writer_register_msgcontentprovider(wr, &_rrep_message_content_provider, _rrep_addrtlvs,
+                                                     ARRAY_SIZE(_rrep_addrtlvs));
     if (res < 0) {
         DEBUG("rfc5444_writer: couldn't reigster RREQ message provider\n");
         return;
     }
 
-    _rreq_msg = rfc5444_writer_register_message(writer, RFC5444_MSGTYPE_RREQ,
-                                                false, RFC5444_MAX_ADDRLEN);
+    _rreq_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREQ, false, RFC5444_MAX_ADDRLEN);
     if (_rreq_msg == NULL) {
         DEBUG("rfc5444_writer: couldn't reigster RREQ message\n");
         return;
     }
 
-    _rrep_msg = rfc5444_writer_register_message(writer, RFC5444_MSGTYPE_RREP,
-                                                false, RFC5444_MAX_ADDRLEN);
+    _rrep_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREP, false, RFC5444_MAX_ADDRLEN);
     if (_rrep_msg == NULL) {
         DEBUG("rfc5444_writer: couldn't reigster RREP message\n");
         return;

--- a/sys/shell_extended/sc_aodvv2.c
+++ b/sys/shell_extended/sc_aodvv2.c
@@ -55,13 +55,13 @@ static int _rcs_add(int argc, char **argv)
 
     char *addr_str = argv[0];
 
+    uint8_t pfx_len = _get_pfx_len(addr_str);
+
     ipv6_addr_t addr;
     if (ipv6_addr_from_str(&addr, addr_str) == NULL) {
         printf("error: unable to parse IPv6 address\n");
         return 1;
     }
-
-    uint8_t pfx_len = _get_pfx_len(addr_str);
 
     if (aodvv2_rcs_add(&addr, pfx_len, 1) == NULL) {
         printf("error: unable to add client to RCS\n");


### PR DESCRIPTION
This changes the code to use the prefix lengths correctly, this means, not loosing prefix length data at conversion time, and using the prefix length on the NIB.

**Note:** this needs to be tested. I'll setup the Renode environment to test against various nodes, and with the Launchpads (without hops, but to verify on hardware anyway).

Reviews are welcome. 