### PR TITLE
vaina: add pfx_len field to RCS ops

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ host-tools:
 sliptty:
 	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)/sliptty
 
-  IPV6_PREFIX = 2001:db8::/64
+  IPV6_PREFIX = "fc00::/16"
 
 # Configure terminal parameters
   TERMDEPS += host-tools

--- a/dist/tools/vaina/autoconfigure.sh
+++ b/dist/tools/vaina/autoconfigure.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 
 TUN=sl0
-PREFIX=128
-TUN_GLB="2001::200:0:cafe" # Dirección global de prueba
+PREFIX=64
+TUN_GLB="fc00:db8::1" # Dirección global de prueba
 SCRIPT=$(readlink -f "$0")
 BASEDIR=$(dirname "$SCRIPT")
 
@@ -29,12 +29,13 @@ add_addresses() {
         Linux)
             cargo build --release
             ${SUDO} ip address add ${TUN_GLB} dev ${TUN}
-            ${SUDO} target/release/vaina rcs add ${TUN} ${TUN_GLB}
+            ${SUDO} target/release/vaina rcs add ${TUN} ${PREFIX} ${TUN_GLB}
             ${SUDO} target/release/vaina nib add ${TUN} ${PREFIX} ${TUN_GLB}
             ;;
         OSX)
+            cargo build --relesae
 # TODO: add the IPV6 address to the interface!!!
-            ${SUDO} target/release/vaina rcs add ${TUN} ${TUN_GLB}
+            ${SUDO} target/release/vaina rcs add ${TUN} ${PREFIX} ${TUN_GLB}
             ${SUDO} target/release/vaina nib add ${TUN} ${PREFIX} ${TUN_GLB}
             unsupported_platform
             ;;

--- a/dist/tools/vaina/src/cli.yml
+++ b/dist/tools/vaina/src/cli.yml
@@ -46,6 +46,10 @@ subcommands:
                         help: "Network interface (e.g: sl0)"
                         required: true
                         takes_value: true
+                    - prefix:
+                        help: "IPv6 prefix in bits (e.g: 128)"
+                        required: true
+                        takes_value: true
                     - IP:
                         help: "IPv6 address of the client to add"
                         required: true
@@ -55,6 +59,10 @@ subcommands:
                 args:
                     - interface:
                         help: "Network interface (e.g: sl0)"
+                        required: true
+                        takes_value: true
+                    - prefix:
+                        help: "IPv6 prefix in bits (e.g: 128)"
                         required: true
                         takes_value: true
                     - IP:

--- a/dist/tools/vaina/src/msg.rs
+++ b/dist/tools/vaina/src/msg.rs
@@ -24,6 +24,8 @@ pub enum Message {
     RcsAdd {
         /// Sequence number
         seqno: u8,
+        /// IPv6 address prefix
+        prefix: u8,
         /// Entry IPv6 address
         ip: Ipv6Addr,
     },
@@ -31,6 +33,8 @@ pub enum Message {
     RcsDel {
         /// Sequence number
         seqno: u8,
+        /// IPv6 address prefix
+        prefix: u8,
         /// Entry IPv6 address
         ip: Ipv6Addr,
     },
@@ -76,14 +80,16 @@ impl Message {
 
         match *self {
             Message::Ack { .. } | Message::Nack { .. } => {}
-            Message::RcsAdd { seqno, ref ip } => {
+            Message::RcsAdd { seqno, prefix, ref ip } => {
                 buf.put_u8(VAINA_MSG_RCS_ADD);
                 buf.put_u8(seqno);
+                buf.put_u8(prefix);
                 buf.put_slice(&ip.octets());
             }
-            Message::RcsDel { seqno, ref ip } => {
+            Message::RcsDel { seqno, prefix, ref ip } => {
                 buf.put_u8(VAINA_MSG_RCS_DEL);
                 buf.put_u8(seqno);
+                buf.put_u8(prefix);
                 buf.put_slice(&ip.octets());
             }
             Message::NibAdd {

--- a/dist/tools/vaina/src/rcs.rs
+++ b/dist/tools/vaina/src/rcs.rs
@@ -19,6 +19,7 @@ pub fn handle_matches(matches: &ArgMatches) -> Result<(), Error> {
 }
 
 fn add(matches: &ArgMatches) -> Result<(), Error> {
+    let prefix = value_t!(matches, "prefix", u8).unwrap_or_else(|e| e.exit());
     let ip = value_t!(matches, "IP", Ipv6Addr).unwrap_or_else(|e| e.exit());
     let interface = value_t!(matches, "interface", String).unwrap_or_else(|e| e.exit());
     let interface = OsString::from(interface);
@@ -27,6 +28,7 @@ fn add(matches: &ArgMatches) -> Result<(), Error> {
 
     let msg = Message::RcsAdd {
         seqno: client.craft_seqno(),
+        prefix,
         ip,
     };
     client.send_message(&msg)?;
@@ -35,6 +37,7 @@ fn add(matches: &ArgMatches) -> Result<(), Error> {
 }
 
 fn del(matches: &ArgMatches) -> Result<(), Error> {
+    let prefix = value_t!(matches, "prefix", u8).unwrap_or_else(|e| e.exit());
     let ip = value_t!(matches, "IP", Ipv6Addr).unwrap_or_else(|e| e.exit());
     let interface = value_t!(matches, "interface", String).unwrap_or_else(|e| e.exit());
     let interface = OsString::from(interface);
@@ -43,6 +46,7 @@ fn del(matches: &ArgMatches) -> Result<(), Error> {
 
     let msg = Message::RcsDel {
         seqno: client.craft_seqno(),
+        prefix,
         ip,
     };
     client.send_message(&msg)?;

--- a/sys/include/net/vaina.h
+++ b/sys/include/net/vaina.h
@@ -58,6 +58,7 @@ enum {
  * @brief   Router Client Set add message
  */
 typedef struct {
+    uint8_t pfx_len; /**< IP address pfx_len */
     ipv6_addr_t ip; /**< IP address to add */
 } vaina_msg_rcs_add_t;
 
@@ -65,6 +66,7 @@ typedef struct {
  * @brief   Router Client Set delete message
  */
 typedef struct {
+    uint8_t pfx_len; /**< IP address pfx_len */
     ipv6_addr_t ip; /**< IP address to delete */
 } vaina_msg_rcs_del_t;
 
@@ -72,7 +74,7 @@ typedef struct {
  * @brief   NIB add message
  */
 typedef struct {
-    uint8_t prefix; /**< IP address prefix */
+    uint8_t pfx_len; /**< IP address pfx_len */
     ipv6_addr_t ip; /**< IP address to add */
 } vaina_msg_nib_add_t;
 
@@ -80,7 +82,7 @@ typedef struct {
  * @brief   NIB del message
  */
 typedef struct {
-    uint8_t prefix; /**< IP address prefix */
+    uint8_t pfx_len; /**< IP address pfx_len */
     ipv6_addr_t ip; /**< IP address to delete */
 } vaina_msg_nib_del_t;
 

--- a/sys/net/aodvv2/aodvv2_mcmsg.c
+++ b/sys/net/aodvv2/aodvv2_mcmsg.c
@@ -212,6 +212,7 @@ int aodvv2_mcmsg_process(aodvv2_packet_data_t *msg)
             if (_is_compatible_mcmsg(&comparable->data, &entry->data)) {
                 if (entry->data.metric <= comparable->data.metric) {
                     DEBUG_PUTS("aodvv2: received McMsg is worse than stored");
+                    mutex_unlock(&_lock);
                     return AODVV2_MCMSG_REDUNDANT;
                 }
             }


### PR DESCRIPTION
This adds a `pfx_len` field to RCS vaina commands, to properly configure a router prefix correctly.

Depends on #106 