### PR TITLE
oonf_api: update OONF to v0.15.1

### DIFF
--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -140,7 +140,7 @@ static void _send_rreq(aodvv2_packet_data_t *packet_data,
     /* set address to which the _send_packet callback should send our RREQ */
     memcpy(&_writer_context.target_addr, next_hop, sizeof(ipv6_addr_t));
 
-    rfc5444_writer_create_message_alltarget(&_writer, RFC5444_MSGTYPE_RREQ);
+    rfc5444_writer_create_message_alltarget(&_writer, RFC5444_MSGTYPE_RREQ, RFC5444_MAX_ADDRLEN);
     rfc5444_writer_flush(&_writer, &_writer_context.target, false);
 
     mutex_unlock(&_writer_lock);
@@ -164,7 +164,7 @@ static void _send_rrep(aodvv2_packet_data_t *packet_data,
     /* set address to which the _send_packet callback should send our RREQ */
     memcpy(&_writer_context.target_addr, next_hop, sizeof(ipv6_addr_t));
 
-    rfc5444_writer_create_message_alltarget(&_writer, RFC5444_MSGTYPE_RREP);
+    rfc5444_writer_create_message_alltarget(&_writer, RFC5444_MSGTYPE_RREP, RFC5444_MAX_ADDRLEN);
     rfc5444_writer_flush(&_writer, &_writer_context.target, false);
 
     mutex_unlock(&_writer_lock);

--- a/sys/net/aodvv2/rfc5444_writer.c
+++ b/sys/net/aodvv2/rfc5444_writer.c
@@ -27,8 +27,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static void _cb_add_message_header(struct rfc5444_writer *wr,
-                                   struct rfc5444_writer_message *message);
+static int _cb_add_message_header(struct rfc5444_writer *wr, struct rfc5444_writer_message *message);
 static void _cb_rreq_add_addresses(struct rfc5444_writer *wr);
 static void _cb_rrep_add_addresses(struct rfc5444_writer *wr);
 
@@ -78,12 +77,13 @@ static struct rfc5444_writer_message *_rrep_msg;
 
 static aodvv2_writer_target_t *_target;
 
-static void _cb_add_message_header(struct rfc5444_writer *wr,
-                                   struct rfc5444_writer_message *message)
+static int _cb_add_message_header(struct rfc5444_writer *wr, struct rfc5444_writer_message *message)
 {
     /* no originator, no hopcount, has msg_hop_limit, no seqno */
     rfc5444_writer_set_msg_header(wr, message, false, false, true, false);
     rfc5444_writer_set_msg_hoplimit(wr, message, _target->packet_data.msg_hop_limit);
+
+    return 0;
 }
 
 static void _cb_rreq_add_addresses(struct rfc5444_writer *wr)
@@ -183,13 +183,13 @@ void aodvv2_rfc5444_writer_register(struct rfc5444_writer *wr, aodvv2_writer_tar
         return;
     }
 
-    _rreq_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREQ, false, RFC5444_MAX_ADDRLEN);
+    _rreq_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREQ, false);
     if (_rreq_msg == NULL) {
         DEBUG("rfc5444_writer: couldn't reigster RREQ message\n");
         return;
     }
 
-    _rrep_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREP, false, RFC5444_MAX_ADDRLEN);
+    _rrep_msg = rfc5444_writer_register_message(wr, RFC5444_MSGTYPE_RREP, false);
     if (_rrep_msg == NULL) {
         DEBUG("rfc5444_writer: couldn't reigster RREP message\n");
         return;

--- a/sys/oonf_api/common/autobuf.h
+++ b/sys/oonf_api/common/autobuf.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,54 +39,53 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef _COMMON_AUTOBUF_H
 #define _COMMON_AUTOBUF_H
 
 #include <stdarg.h>
 #include <string.h>
 #include <time.h>
-#include <stdbool.h>
+
+#include "common/common_types.h"
 
 /**
  * Auto-sized buffer handler, mostly used for generation of
  * large string buffers.
  */
 struct autobuf {
-  /* total number of bytes allocated in the buffer */
+  /*! total number of bytes allocated in the buffer */
   size_t _total;
 
-  /* currently number of used bytes */
+  /*! currently number of used bytes */
   size_t _len;
 
-  /* pointer to allocated memory */
+  /*! pointer to allocated memory */
   char *_buf;
 
-  /* an error happened since the last stream cleanup */
+  /*! an error happened since the last stream cleanup */
   bool _error;
 };
 
-int abuf_init(struct autobuf *autobuf);
-void abuf_free(struct autobuf *autobuf);
-int abuf_vappendf(struct autobuf *autobuf, const char *fmt,
-    va_list ap) __attribute__ ((format(printf, 2, 0)));
-int abuf_appendf(struct autobuf *autobuf, const char *fmt,
-    ...) __attribute__ ((format(printf, 2, 3)));
-int abuf_puts(struct autobuf * autobuf, const char *s);
-int abuf_strftime(struct autobuf * autobuf,
-    const char *format, const struct tm * tm);
-int abuf_memcpy(struct autobuf * autobuf,
-    const void *p, const size_t len);
-int abuf_memcpy_prepend(struct autobuf *autobuf,
-    const void *p, const size_t len);
-void abuf_pull(struct autobuf * autobuf, size_t len);
-void abuf_hexdump(struct autobuf *out,
-    const char *prefix, void *buffer, size_t length);
+EXPORT int abuf_init(struct autobuf *autobuf);
+EXPORT void abuf_free(struct autobuf *autobuf);
+EXPORT int abuf_vappendf(struct autobuf *autobuf, const char *fmt, va_list ap) __attribute__((format(printf, 2, 0)));
+EXPORT int abuf_appendf(struct autobuf *autobuf, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+EXPORT int abuf_puts(struct autobuf *autobuf, const char *s);
+EXPORT int abuf_strftime(struct autobuf *autobuf, const char *format, const struct tm *tm);
+EXPORT int abuf_memcpy(struct autobuf *autobuf, const void *p, const size_t len);
+EXPORT int abuf_memcpy_prepend(struct autobuf *autobuf, const void *p, const size_t len);
+EXPORT void abuf_pull(struct autobuf *autobuf, size_t len);
+EXPORT void abuf_hexdump(struct autobuf *out, const char *prefix, const void *buffer, size_t length);
 
 /**
  * Clears the content of an autobuf
- * @param autobuf
+ * @param autobuf autobuffer instance
  */
-static inline void
+static INLINE void
 abuf_clear(struct autobuf *autobuf) {
   autobuf->_len = 0;
   autobuf->_error = false;
@@ -94,39 +93,41 @@ abuf_clear(struct autobuf *autobuf) {
 }
 
 /**
- * @param autobuf pointer to autobuf
+ * @param autobuf autobuffer instance
  * @return pointer to internal bufffer memory
  */
-static inline char *
+static INLINE char *
 abuf_getptr(struct autobuf *autobuf) {
   return autobuf->_buf;
 }
 
 /**
- * @param autobuf pointer to autobuf
+ * @param autobuf autobuffer instance
  * @return number of bytes stored in autobuf
  */
-static inline size_t
+static INLINE size_t
 abuf_getlen(struct autobuf *autobuf) {
   return autobuf->_len;
 }
 
 /**
- * @param autobuf pointer to autobuf
+ * @param autobuf autobuffer instance
  * @return number of bytes allocated in buffer
  */
-static inline size_t
+static INLINE size_t
 abuf_getmax(struct autobuf *autobuf) {
   return autobuf->_total;
 }
 
 /**
- *
- * @param autobuf
- * @param len
+ * set the length of the autobuffer, will truncate the length
+ * by the total amount of memory in the buffer. Normally used
+ * to shorten a buffer.
+ * @param autobuf autobuffer instance
+ * @param len new length of the autobuffer
  */
-static inline void
-abuf_setlen(struct autobuf * autobuf, size_t len) {
+static INLINE void
+abuf_setlen(struct autobuf *autobuf, size_t len) {
   if (autobuf->_total > len) {
     autobuf->_len = len;
   }
@@ -136,43 +137,43 @@ abuf_setlen(struct autobuf * autobuf, size_t len) {
 
 /**
  * Append a single byte to an autobuffer
- * @param autobuf
+ * @param autobuf autobuffer instance
  * @param c byte to append
  * @return -1 if an error happened, 0 otherwise
  */
-static inline int
+static INLINE int
 abuf_append_uint8(struct autobuf *autobuf, const uint8_t c) {
   return abuf_memcpy(autobuf, &c, 1);
 }
 
 /**
  * Append a uint16 to an autobuffer
- * @param autobuf
+ * @param autobuf autobuffer instance
  * @param s uint16 to append
  * @return -1 if an error happened, 0 otherwise
  */
-static inline int
+static INLINE int
 abuf_append_uint16(struct autobuf *autobuf, const uint16_t s) {
   return abuf_memcpy(autobuf, &s, 2);
 }
 
 /**
  * Append a uint32 to an autobuffer
- * @param autobuf
+ * @param autobuf autobuffer instance
  * @param l uint32 to append
  * @return -1 if an error happened, 0 otherwise
  */
-static inline int
+static INLINE int
 abuf_append_uint32(struct autobuf *autobuf, const uint32_t l) {
   return abuf_memcpy(autobuf, &l, 4);
 }
 
 /**
- * @param autobuf
+ * @param autobuf autobuffer instance
  * @return true if an autobuf function failed
  *  since the last cleanup of the stream
  */
-static inline bool
+static INLINE bool
 abuf_has_failed(struct autobuf *autobuf) {
   return autobuf->_error;
 }

--- a/sys/oonf_api/common/avl_comp.c
+++ b/sys/oonf_api/common/avl_comp.c
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,15 +39,18 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #include <string.h>
 #include <strings.h>
 
 #include "common/avl_comp.h"
-#include "common/netaddr.h"
+#include "common/string.h"
 
 /**
  * AVL tree comparator for unsigned 32 bit integers
- * Custom pointer is not used.
  * @param k1 pointer to key 1
  * @param k2 pointer to key 2
  * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2
@@ -67,8 +70,27 @@ avl_comp_uint32(const void *k1, const void *k2) {
 }
 
 /**
+ * AVL tree comparator for signed 32 bit integers
+ * @param k1 pointer to key 1
+ * @param k2 pointer to key 2
+ * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2
+ */
+int
+avl_comp_int32(const void *k1, const void *k2) {
+  const int32_t *i1 = k1;
+  const int32_t *i2 = k2;
+
+  if (*i1 > *i2) {
+    return 1;
+  }
+  if (*i2 > *i1) {
+    return -1;
+  }
+  return 0;
+}
+
+/**
  * AVL tree comparator for unsigned 16 bit integers
- * Custom pointer is not used.
  * @param k1 pointer to key 1
  * @param k2 pointer to key 2
  * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2
@@ -89,7 +111,6 @@ avl_comp_uint16(const void *k1, const void *k2) {
 
 /**
  * AVL tree comparator for unsigned 8 bit integers
- * Custom pointer is not used
  * @param k1 pointer to key 1
  * @param k2 pointer to key 2
  * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2
@@ -122,8 +143,20 @@ avl_comp_netaddr(const void *k1, const void *k2) {
 }
 
 /**
+ * AVL tree comparator for netaddr objects.
+ * @param k1 pointer to key 1
+ * @param k2 pointer to key 2
+ * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2
+ */
+int
+avl_comp_netaddr_socket(const void *k1, const void *k2) {
+  const union netaddr_socket *s1 = k1;
+  const union netaddr_socket *s2 = k2;
+  return memcmp(s1, s2, sizeof(union netaddr_socket));
+}
+
+/**
  * AVL tree comparator for case insensitive strings.
- * Custom pointer is the length of the memory to compare.
  * @param txt1 pointer to string 1
  * @param txt2 pointer to string 2
  * @return +1 if k1>k2, -1 if k1<k2, 0 if k1==k2

--- a/sys/oonf_api/common/avl_comp.h
+++ b/sys/oonf_api/common/avl_comp.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,13 +39,22 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef AVL_COMP_H_
 #define AVL_COMP_H_
 
-int avl_comp_uint32(const void *k1, const void *k2);
-int avl_comp_uint16(const void *k1, const void *k2);
-int avl_comp_uint8(const void *k1, const void *k2);
-int avl_comp_netaddr(const void *k1, const void *k2);
-int avl_comp_strcasecmp(const void *, const void *);
+#include "common/common_types.h"
+#include "common/netaddr.h"
+
+EXPORT int avl_comp_uint32(const void *k1, const void *k2);
+EXPORT int avl_comp_int32(const void *k1, const void *k2);
+EXPORT int avl_comp_uint16(const void *k1, const void *k2);
+EXPORT int avl_comp_uint8(const void *k1, const void *k2);
+EXPORT int avl_comp_netaddr(const void *k1, const void *k2);
+EXPORT int avl_comp_netaddr_socket(const void *k1, const void *k2);
+EXPORT int avl_comp_strcasecmp(const void *, const void *);
 
 #endif /* AVL_COMP_H_ */

--- a/sys/oonf_api/common/bitmap256.c
+++ b/sys/oonf_api/common/bitmap256.c
@@ -42,44 +42,25 @@
 /**
  * @file
  */
-#ifndef PRINT_RFC5444_H_
-#define PRINT_RFC5444_H_
 
-#include "common/autobuf.h"
 #include "common/common_types.h"
-#include "rfc5444_reader.h"
+
+#include "bitmap256.h"
 
 /**
- * RFC5444 printer session
+ * Test if a bitmap is a subset of another bitmap
+ * @param set reference bitmap
+ * @param subset potential subset bitmap
+ * @return true if it is a subset of the reference, false otherwise
  */
-struct rfc5444_print_session {
-  /*! output buffer */
-  struct autobuf *output;
+bool
+bitmap256_is_subset(struct bitmap256 *set, struct bitmap256 *subset) {
+  size_t i;
 
-  /**
-   * Callback to print RFC5444 packet text representation
-   * @param session printer session
-   */
-  void (*print_packet)(struct rfc5444_print_session *session);
-
-  /*! packet consumer */
-  struct rfc5444_reader_tlvblock_consumer _pkt;
-
-  /*! message consumer */
-  struct rfc5444_reader_tlvblock_consumer _msg;
-
-  /*! address consumer */
-  struct rfc5444_reader_tlvblock_consumer _addr;
-
-  /*! rfc5444 reader */
-  struct rfc5444_reader *_reader;
-};
-
-EXPORT void rfc5444_print_add(struct rfc5444_print_session *, struct rfc5444_reader *reader);
-EXPORT void rfc5444_print_remove(struct rfc5444_print_session *session);
-
-EXPORT enum rfc5444_result rfc5444_print_direct(struct autobuf *out, void *buffer, size_t length);
-
-EXPORT int rfc5444_print_raw(struct autobuf *out, void *buffer, size_t length);
-
-#endif /* PRINT_RFC5444_H_ */
+  for (i = 0; i < ARRAYSIZE(set->b); i++) {
+    if (set->b[i] != (set->b[i] | subset->b[i])) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/sys/oonf_api/common/bitmap256.h
+++ b/sys/oonf_api/common/bitmap256.h
@@ -42,44 +42,57 @@
 /**
  * @file
  */
-#ifndef PRINT_RFC5444_H_
-#define PRINT_RFC5444_H_
 
-#include "common/autobuf.h"
+#ifndef DLEP_SIGNAL_H_
+#define DLEP_SIGNAL_H_
+
 #include "common/common_types.h"
-#include "rfc5444_reader.h"
+
+/*! keyword for setting all bits in a bitmap */
+#define BITMAP256_ALL "all"
+
+/*! keyword for clearing all bits in a bitmap */
+#define BITMAP256_NONE "none"
 
 /**
- * RFC5444 printer session
+ * Bitarray with 256 bits length
  */
-struct rfc5444_print_session {
-  /*! output buffer */
-  struct autobuf *output;
-
-  /**
-   * Callback to print RFC5444 packet text representation
-   * @param session printer session
-   */
-  void (*print_packet)(struct rfc5444_print_session *session);
-
-  /*! packet consumer */
-  struct rfc5444_reader_tlvblock_consumer _pkt;
-
-  /*! message consumer */
-  struct rfc5444_reader_tlvblock_consumer _msg;
-
-  /*! address consumer */
-  struct rfc5444_reader_tlvblock_consumer _addr;
-
-  /*! rfc5444 reader */
-  struct rfc5444_reader *_reader;
+struct bitmap256 {
+  /*! array for 256 bits */
+  uint64_t b[256 / sizeof(uint64_t) / 8];
 };
 
-EXPORT void rfc5444_print_add(struct rfc5444_print_session *, struct rfc5444_reader *reader);
-EXPORT void rfc5444_print_remove(struct rfc5444_print_session *session);
+EXPORT bool bitmap256_is_subset(struct bitmap256 *set, struct bitmap256 *subset);
 
-EXPORT enum rfc5444_result rfc5444_print_direct(struct autobuf *out, void *buffer, size_t length);
+/**
+ * get a bit of the bit array
+ * @param map pointer to bit array
+ * @param bit index of bit
+ * @return content of the bit
+ */
+static inline bool
+bitmap256_get(struct bitmap256 *map, uint8_t bit) {
+  return ((map->b[bit >> 6]) & (1ull << (bit & 63ull))) != 0;
+}
 
-EXPORT int rfc5444_print_raw(struct autobuf *out, void *buffer, size_t length);
+/**
+ * set a bit of the bit array
+ * @param map pointer to bit array
+ * @param bit index of bit
+ */
+static inline void
+bitmap256_set(struct bitmap256 *map, uint8_t bit) {
+  map->b[bit >> 6] |= 1ull << (bit & 63ull);
+}
 
-#endif /* PRINT_RFC5444_H_ */
+/**
+ * reset a bit of the bit array
+ * @param map pointer to bit array
+ * @param bit index of bit
+ */
+static inline void
+bitmap256_reset(struct bitmap256 *map, uint8_t bit) {
+  map->b[bit >> 6] &= ~(1ull << (bit & 63ull));
+}
+
+#endif /* DLEP_SIGNAL_H_ */

--- a/sys/oonf_api/common/common_types.h
+++ b/sys/oonf_api/common/common_types.h
@@ -42,44 +42,70 @@
 /**
  * @file
  */
-#ifndef PRINT_RFC5444_H_
-#define PRINT_RFC5444_H_
 
-#include "common/autobuf.h"
-#include "common/common_types.h"
-#include "rfc5444_reader.h"
+#ifndef COMMON_TYPES_H_
+#define COMMON_TYPES_H_
 
-/**
- * RFC5444 printer session
+#include <stddef.h>
+
+/*
+ * This line forces gcc NOT to demand memcpy with glibc version 2.14
+ * google for the memcpy/memmove debacle with gcc and glibc.
  */
-struct rfc5444_print_session {
-  /*! output buffer */
-  struct autobuf *output;
+// __asm__(".symver memcpy,memcpy@GLIBC_2.2.5");
 
-  /**
-   * Callback to print RFC5444 packet text representation
-   * @param session printer session
-   */
-  void (*print_packet)(struct rfc5444_print_session *session);
+#ifndef EXPORT
+/*! Macro to declare a function should be visible for other subsystems */
+#define EXPORT __attribute__((visibility("default")))
+#endif
 
-  /*! packet consumer */
-  struct rfc5444_reader_tlvblock_consumer _pkt;
+/* give everyone an arraysize implementation */
+#ifndef ARRAYSIZE
+/**
+ * @param a reference of an array (not a pointer!)
+ * @returns number of elements in array
+ */
+#define ARRAYSIZE(a) (sizeof(a) / sizeof(*(a)))
+#endif
 
-  /*! message consumer */
-  struct rfc5444_reader_tlvblock_consumer _msg;
+#ifndef STRINGIFY
+/*! converts the parameter of the macro into a string */
+#define STRINGIFY(x) #x
+#endif
 
-  /*! address consumer */
-  struct rfc5444_reader_tlvblock_consumer _addr;
+/*
+ * This force gcc to always inline, which prevents errors
+ * with option -Os
+ */
+#ifndef INLINE
+#ifdef __GNUC__
+/*! force inlining with GCC */
+#define INLINE inline __attribute__((always_inline))
+#else
+/*! default to normal inlining */
+#define INLINE inline
+#endif
+#endif
 
-  /*! rfc5444 reader */
-  struct rfc5444_reader *_reader;
-};
+/* printf size_t modifiers*/
+#if defined(__GNUC__)
+#define PRINTF_SIZE_T_SPECIFIER "zu"
+#define PRINTF_SIZE_T_HEX_SPECIFIER "zx"
+#define PRINTF_SSIZE_T_SPECIFIER "zd"
+#define PRINTF_PTRDIFF_T_SPECIFIER "zd"
+#else
+/* maybe someone can check what to do about LLVM/Clang? */
+#error Please implement size_t modifiers
+#endif
 
-EXPORT void rfc5444_print_add(struct rfc5444_print_session *, struct rfc5444_reader *reader);
-EXPORT void rfc5444_print_remove(struct rfc5444_print_session *session);
+#include <limits.h>
 
-EXPORT enum rfc5444_result rfc5444_print_direct(struct autobuf *out, void *buffer, size_t length);
+/* we have C99 ? */
+#if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+#include <inttypes.h>
+#include <stdbool.h>
+#else
+#error "OONF needs C99"
+#endif /* __STDC_VERSION__ && __STDC_VERSION__ >= 199901L */
 
-EXPORT int rfc5444_print_raw(struct autobuf *out, void *buffer, size_t length);
-
-#endif /* PRINT_RFC5444_H_ */
+#endif /* COMMON_TYPES_H_ */

--- a/sys/oonf_api/common/list.h
+++ b/sys/oonf_api/common/list.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,14 +39,21 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef LIST_H_
 #define LIST_H_
 
 #include <stddef.h>
-#include <stdbool.h>
 
-#include "kernel_defines.h"
+#include "common/common_types.h"
 #include "common/container_of.h"
+
+#ifdef RIOT_VERSION
+#include "kernel_defines.h"
+#endif
 
 /**
  * this struct is used as list head and list elements.
@@ -55,31 +62,27 @@
  * have a link to the head, no NULL element.
  */
 struct oonf_list_entity {
-  /**
-   * Pointer to next element in list or to list head if last element
-   */
+  /*! pointer to next element in list or to list head if last element */
   struct oonf_list_entity *next;
 
-  /**
-   * Pointer to previous element in list or list head if first element
-   */
+  /*! Pointer to previous element in list or list head if first element */
   struct oonf_list_entity *prev;
 };
 
 /**
  * initialize a list-head
- * @param pointer to list-head
+ * @param head to list-head
  */
-static inline void
+static INLINE void
 oonf_list_init_head(struct oonf_list_entity *head) {
   head->next = head->prev = head;
 }
 
 /**
  * initialize a list-node
- * @param pointer to list-node
+ * @param entity to list-node
  */
-static inline void
+static INLINE void
 oonf_list_init_node(struct oonf_list_entity *entity) {
   entity->next = entity->prev = NULL;
 }
@@ -90,7 +93,7 @@ oonf_list_init_node(struct oonf_list_entity *entity) {
  * @param next node after the insertion point
  * @param new node which will be added to the list between 'prev' and 'next'
  */
-static inline void
+static INLINE void
 __oonf_list_add(struct oonf_list_entity *prev, struct oonf_list_entity *next, struct oonf_list_entity *new) {
   new->next = next;
   new->prev = prev;
@@ -103,7 +106,7 @@ __oonf_list_add(struct oonf_list_entity *prev, struct oonf_list_entity *next, st
  * @param head pointer to list head
  * @param new node which will be added to the list
  */
-static inline void
+static INLINE void
 oonf_list_add_head(struct oonf_list_entity *head, struct oonf_list_entity *new) {
   __oonf_list_add(head, head->next, new);
 }
@@ -113,7 +116,7 @@ oonf_list_add_head(struct oonf_list_entity *head, struct oonf_list_entity *new) 
  * @param head pointer to list head
  * @param new node which will be added to the list
  */
-static inline void
+static INLINE void
 oonf_list_add_tail(struct oonf_list_entity *head, struct oonf_list_entity *new) {
   __oonf_list_add(head->prev, head, new);
 }
@@ -123,17 +126,17 @@ oonf_list_add_tail(struct oonf_list_entity *head, struct oonf_list_entity *new) 
  * @param before reference node in the list
  * @param new node which will be added to the list
  */
-static inline void
+static INLINE void
 oonf_list_add_before(struct oonf_list_entity *before, struct oonf_list_entity *new) {
   __oonf_list_add(before->prev, before, new);
 }
 
 /**
  * adds a node after another node
- * @param before reference node in the list
+ * @param after reference node in the list
  * @param new node which will be added to the list
  */
-static inline void
+static INLINE void
 oonf_list_add_after(struct oonf_list_entity *after, struct oonf_list_entity *new) {
   __oonf_list_add(after, after->next, new);
 }
@@ -143,7 +146,7 @@ oonf_list_add_after(struct oonf_list_entity *after, struct oonf_list_entity *new
  * @param prev node before the removed part of the list
  * @param next node after the removed part of the list
  */
-static inline void
+static INLINE void
 __oonf_list_remove(struct oonf_list_entity *prev, struct oonf_list_entity *next) {
   prev->next = next;
   next->prev = prev;
@@ -153,7 +156,7 @@ __oonf_list_remove(struct oonf_list_entity *prev, struct oonf_list_entity *next)
  * removes a node from a list and clears node pointers
  * @param entity node to remove from the list
  */
-static inline void
+static INLINE void
 oonf_list_remove(struct oonf_list_entity *entity) {
   __oonf_list_remove(entity->prev, entity->next);
   oonf_list_init_node(entity);
@@ -164,8 +167,8 @@ oonf_list_remove(struct oonf_list_entity *entity) {
  * @param head pointer to list head
  * @return true if list is empty, false otherwise
  */
-static inline bool
-oonf_list_is_empty(struct oonf_list_entity *head) {
+static INLINE bool
+oonf_list_is_empty(const struct oonf_list_entity *head) {
   return head->next == head && head->prev == head;
 }
 
@@ -175,8 +178,8 @@ oonf_list_is_empty(struct oonf_list_entity *head) {
  * @return true if both pointers of the node are initialized,
  *   false otherwise
  */
-static inline bool
-oonf_list_is_node_added(struct oonf_list_entity *node) {
+static INLINE bool
+oonf_list_is_node_added(const struct oonf_list_entity *node) {
   return node->next != NULL && node->prev != NULL;
 }
 
@@ -186,7 +189,7 @@ oonf_list_is_node_added(struct oonf_list_entity *node) {
  * @param entity pointer to node
  * @return true if node is first element of list, false otherwise
  */
-static inline bool
+static INLINE bool
 oonf_list_is_first(const struct oonf_list_entity *head, const struct oonf_list_entity *entity) {
   return head->next == entity;
 }
@@ -197,7 +200,7 @@ oonf_list_is_first(const struct oonf_list_entity *head, const struct oonf_list_e
  * @param entity pointer to node
  * @return true if node is last element of list, false otherwise
  */
-static inline bool
+static INLINE bool
 oonf_list_is_last(const struct oonf_list_entity *head, const struct oonf_list_entity *entity) {
   return head->prev == entity;
 }
@@ -208,16 +211,17 @@ oonf_list_is_last(const struct oonf_list_entity *head, const struct oonf_list_en
  * @param remove_from head of the list which elements will be added after the elements
  *   of the first one
  */
-static inline void
+static INLINE void
 oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove_from) {
   if (oonf_list_is_empty(remove_from)) {
     return;
   }
 
-  add_to->next->prev = remove_from->prev;
-  remove_from->prev->next = add_to->next;
-  add_to->next = remove_from->next;
-  remove_from->next->prev = add_to;
+  add_to->prev->next = remove_from->next;
+  remove_from->next->prev = add_to->prev;
+
+  add_to->prev = remove_from->prev;
+  remove_from->prev->next = add_to;
 
   oonf_list_init_head(remove_from);
 }
@@ -231,8 +235,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @return pointer to the first element of the list
  *    (automatically converted to type 'element')
  */
-#define oonf_list_first_element(head, element, oonf_list_member) \
-    container_of((head)->next, typeof(*(element)), oonf_list_member)
+#define oonf_list_first_element(head, element, oonf_list_member) container_of((head)->next, typeof(*(element)), oonf_list_member)
 
 /**
  * @param head pointer to list-head
@@ -243,8 +246,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @return pointer to the last element of the list
  *    (automatically converted to type 'element')
  */
-#define oonf_list_last_element(head, element, oonf_list_member) \
-    container_of((head)->prev, typeof(*(element)), oonf_list_member)
+#define oonf_list_last_element(head, element, oonf_list_member) container_of((head)->prev, typeof(*(element)), oonf_list_member)
 
 /**
  * This function must not be called for the last element of
@@ -256,7 +258,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @return pointer to the node after 'element'
  *    (automatically converted to type 'element')
  */
-#define oonf_list_next_element(element, oonf_list_member) \
+#define oonf_list_next_element(element, oonf_list_member)                                                                        \
   container_of((&(element)->oonf_list_member)->next, typeof(*(element)), oonf_list_member)
 
 /**
@@ -269,7 +271,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @return pointer to the node before 'element'
  *    (automatically converted to type 'element')
  */
-#define oonf_list_prev_element(element, oonf_list_member) \
+#define oonf_list_prev_element(element, oonf_list_member)                                                                        \
   container_of((&(element)->oonf_list_member)->prev, typeof(*(element)), oonf_list_member)
 
 /**
@@ -282,9 +284,8 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param element iterator pointer to list element struct
  * @param oonf_list_member name of oonf_list_entity within list element struct
  */
-#define oonf_list_for_element_range(first_element, last_element, element, oonf_list_member) \
-  for (element = (first_element); \
-       element->oonf_list_member.prev != &(last_element)->oonf_list_member; \
+#define oonf_list_for_element_range(first_element, last_element, element, oonf_list_member)                                      \
+  for (element = (first_element); element->oonf_list_member.prev != &(last_element)->oonf_list_member;                           \
        element = oonf_list_next_element(element, oonf_list_member))
 
 /**
@@ -297,9 +298,8 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param element iterator pointer to list element struct
  * @param oonf_list_member name of oonf_list_entity within list element struct
  */
-#define oonf_list_for_element_range_reverse(first_element, last_element, element, oonf_list_member) \
-  for (element = (last_element); \
-       element->oonf_list_member.next != &(first_element)->oonf_list_member; \
+#define oonf_list_for_element_range_reverse(first_element, last_element, element, oonf_list_member)                              \
+  for (element = (last_element); element->oonf_list_member.next != &(first_element)->oonf_list_member;                           \
        element = oonf_list_prev_element(element, oonf_list_member))
 
 /**
@@ -313,10 +313,9 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_each_element(head, element, oonf_list_member) \
-  oonf_list_for_element_range(oonf_list_first_element(head, element, oonf_list_member), \
-                         oonf_list_last_element(head, element, oonf_list_member), \
-                         element, oonf_list_member)
+#define oonf_list_for_each_element(head, element, oonf_list_member)                                                              \
+  oonf_list_for_element_range(oonf_list_first_element(head, element, oonf_list_member),                                               \
+    oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member)
 
 /**
  * Loop over all elements of a list backwards, used similar to a for() command.
@@ -329,10 +328,9 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_each_element_reverse(head, element, oonf_list_member) \
-  oonf_list_for_element_range_reverse(oonf_list_first_element(head, element, oonf_list_member), \
-                                 oonf_list_last_element(head, element, oonf_list_member), \
-                                 element, oonf_list_member)
+#define oonf_list_for_each_element_reverse(head, element, oonf_list_member)                                                      \
+  oonf_list_for_element_range_reverse(oonf_list_first_element(head, element, oonf_list_member),                                       \
+    oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member)
 
 /**
  * Loop over a block of elements of a list, used similar to a for() command.
@@ -347,7 +345,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_element_to_last(head, first, element, oonf_list_member) \
+#define oonf_list_for_element_to_last(head, first, element, oonf_list_member)                                                    \
   oonf_list_for_element_range(first, oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member)
 
 /**
@@ -363,7 +361,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_element_to_last_reverse(head, first, element, oonf_list_member) \
+#define oonf_list_for_element_to_last_reverse(head, first, element, oonf_list_member)                                            \
   oonf_list_for_element_range_reverse(first, oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member)
 
 /**
@@ -379,7 +377,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_first_to_element(head, last, element, oonf_list_member) \
+#define oonf_list_for_first_to_element(head, last, element, oonf_list_member)                                                    \
   oonf_list_for_element_range(oonf_list_first_element(head, element, oonf_list_member), last, element, oonf_list_member)
 
 /**
@@ -395,7 +393,7 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param oonf_list_member name of the oonf_list_entity element inside the
  *    larger struct
  */
-#define oonf_list_for_first_to_element_reverse(head, last, element, oonf_list_member) \
+#define oonf_list_for_first_to_element_reverse(head, last, element, oonf_list_member)                                            \
   oonf_list_for_element_range_reverse(oonf_list_first_element(head, element, oonf_list_member), last, element, oonf_list_member)
 
 /**
@@ -411,9 +409,9 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param ptr pointer to list element struct which is used to store
  *    the next node during the loop
  */
-#define oonf_list_for_element_range_safe(first_element, last_element, element, oonf_list_member, ptr) \
-  for (element = (first_element), ptr = oonf_list_next_element(element, oonf_list_member); \
-       element->oonf_list_member.prev != &(last_element)->oonf_list_member; \
+#define oonf_list_for_element_range_safe(first_element, last_element, element, oonf_list_member, ptr)                            \
+  for (element = (first_element), ptr = oonf_list_next_element(element, oonf_list_member);                                       \
+       element->oonf_list_member.prev != &(last_element)->oonf_list_member;                                                      \
        element = ptr, ptr = oonf_list_next_element(ptr, oonf_list_member))
 
 /**
@@ -429,9 +427,9 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param ptr pointer to list element struct which is used to store
  *    the previous node during the loop
  */
-#define oonf_list_for_element_range_reverse_safe(first_element, last_element, element, oonf_list_member, ptr) \
-  for (element = (last_element), ptr = oonf_list_prev_element(element, oonf_list_member); \
-       element->oonf_list_member.next != &(first_element)->oonf_list_member; \
+#define oonf_list_for_element_range_reverse_safe(first_element, last_element, element, oonf_list_member, ptr)                    \
+  for (element = (last_element), ptr = oonf_list_prev_element(element, oonf_list_member);                                        \
+       element->oonf_list_member.next != &(first_element)->oonf_list_member;                                                     \
        element = ptr, ptr = oonf_list_prev_element(ptr, oonf_list_member))
 
 /**
@@ -448,10 +446,9 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param ptr pointer to an list element struct which is used to store
  *    the next node during the loop
  */
-#define oonf_list_for_each_element_safe(head, element, oonf_list_member, ptr) \
-  oonf_list_for_element_range_safe(oonf_list_first_element(head, element, oonf_list_member), \
-                              oonf_list_last_element(head, element, oonf_list_member), \
-                              element, oonf_list_member, ptr)
+#define oonf_list_for_each_element_safe(head, element, oonf_list_member, ptr)                                                    \
+  oonf_list_for_element_range_safe(oonf_list_first_element(head, element, oonf_list_member),                                          \
+    oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member, ptr)
 
 /**
  * Loop over all elements of a list backwards, used similar to a for() command.
@@ -467,9 +464,8 @@ oonf_list_merge(struct oonf_list_entity *add_to, struct oonf_list_entity *remove
  * @param ptr pointer to an list element struct which is used to store
  *    the next node during the loop
  */
-#define oonf_list_for_each_element_reverse_safe(head, element, oonf_list_member, ptr) \
-  oonf_list_for_element_range_reverse_safe(oonf_list_first_element(head, element, oonf_list_member), \
-                                      oonf_list_last_element(head, element, oonf_list_member), \
-                                      element, oonf_list_member, ptr)
+#define oonf_list_for_each_element_reverse_safe(head, element, oonf_list_member, ptr)                                            \
+  oonf_list_for_element_range_reverse_safe(oonf_list_first_element(head, element, oonf_list_member),                                  \
+    oonf_list_last_element(head, element, oonf_list_member), element, oonf_list_member, ptr)
 
 #endif /* LIST_H_ */

--- a/sys/oonf_api/common/netaddr.c
+++ b/sys/oonf_api/common/netaddr.c
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,21 +39,111 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #include <ctype.h>
+#ifndef RIOT_VERSION
+#include <net/if.h>
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "common/common_types.h"
 #include "common/netaddr.h"
+#include "common/string.h"
 
-static char *_mac_to_string(char *dst, const void *bin, size_t dst_size,
-    size_t bin_size, char separator);
-static int _mac_from_string(void *bin, size_t bin_size,
-    const char *src, char separator);
+static char *_mac_to_string(char *dst, size_t dst_size, const void *bin, size_t bin_size, char separator);
+static char *_uuid_to_string(char *dst, size_t dst_size, const void *bin, size_t bin_size);
+static int _bin_from_hex(void *bin, size_t bin_size, const char *src, char separator);
+static int _uuid_from_string(void *bin, size_t bin_size, const char *src);
 static int _subnetmask_to_prefixlen(const char *src);
 static int _read_hexdigit(const char c);
-static bool _binary_is_in_subnet(const struct netaddr *subnet,
-    const void *bin);
+static bool _binary_is_in_subnet(const struct netaddr *subnet, const void *bin);
+
+/* predefined network prefixes */
+
+/*! unspecified network address */
+const struct netaddr NETADDR_UNSPEC = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_UNSPEC, 0 };
+
+/*! IPv4 default prefix */
+const struct netaddr NETADDR_IPV4_ANY = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET, 0 };
+
+/*! IPv6 default prefix */
+const struct netaddr NETADDR_IPV6_ANY = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 0 };
+
+/*! IPv4 NULL address */
+const struct netaddr NETADDR_IPV4_BINDTO_ANY = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET, 32 };
+
+/*! IPv6 NULL address */
+const struct netaddr NETADDR_IPV6_BINDTO_ANY = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 128 };
+
+/*! IPv4 multicast prefix */
+const struct netaddr NETADDR_IPV4_MULTICAST = { { 224, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET, 4 };
+
+/*! IPv6 multicast prefix */
+const struct netaddr NETADDR_IPV6_MULTICAST = { { 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 8 };
+
+/*! IPv4 linklocal prefix */
+const struct netaddr NETADDR_IPV4_LINKLOCAL = { { 169, 254, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET, 16 };
+
+/*! IPv6 linklocal prefix */
+const struct netaddr NETADDR_IPV6_LINKLOCAL = { { 0xfe, 0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6,
+  10 };
+
+/*! IPv6 unique local prefix */
+const struct netaddr NETADDR_IPV6_ULA = { { 0xfc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 7 };
+
+/*! IPv6 routable prefix */
+const struct netaddr NETADDR_IPV6_GLOBAL = { { 0x20, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 3 };
+
+/*! IPv6 ipv4-compatible prefix */
+const struct netaddr NETADDR_IPV6_IPV4COMPATIBLE = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET6, 96 };
+
+/*! IPv6 ipv4-mapped prefix */
+const struct netaddr NETADDR_IPV6_IPV4MAPPED = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0, 0, 0 }, AF_INET6,
+  96 };
+
+/*! IPv4 loopback prefix */
+const struct netaddr NETADDR_IPV4_LOOPBACK_NET = { { 127, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }, AF_INET, 8 };
+
+/*! IPv6 loopback address */
+const struct netaddr NETADDR_IPV6_LOOPBACK = { { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1 }, AF_INET6, 128 };
+
+/*! Ethernet broadcast */
+const struct netaddr NETADDR_MAC48_BROADCAST = { { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+  AF_MAC48, 48 };
+
+/*! socket for binding to any IPv4 address */
+const union netaddr_socket NETADDR_SOCKET_IPV4_ANY = { .v4 = {
+                                                         .sin_family = AF_INET,
+                                                         .sin_port = 0,
+                                                         .sin_addr.s_addr = 0,
+                                                       } };
+
+/*! socket for binding to any IPv6 address */
+const union netaddr_socket NETADDR_SOCKET_IPV6_ANY = { .v6 = {
+                                                         .sin6_family = AF_INET6,
+                                                         .sin6_port = 0,
+#if 0
+                                                         .sin6_addr.s6_addr32 = { 0, 0, 0, 0 },
+#endif
+                                                         .sin6_scope_id = 0,
+                                                       } };
+
+/* List of predefined address prefixes */
+static const struct {
+  const char *name;
+  const struct netaddr *prefix;
+} _known_prefixes[] = {
+  { NETADDR_STR_ANY4, &NETADDR_IPV4_ANY },
+  { NETADDR_STR_ANY6, &NETADDR_IPV6_ANY },
+  { NETADDR_STR_LINKLOCAL4, &NETADDR_IPV4_LINKLOCAL },
+  { NETADDR_STR_LINKLOCAL6, &NETADDR_IPV6_LINKLOCAL },
+  { NETADDR_STR_ULA, &NETADDR_IPV6_ULA },
+};
 
 /**
  * Read the binary representation of an address into a netaddr object
@@ -68,9 +158,7 @@ static bool _binary_is_in_subnet(const struct netaddr *subnet,
  *     of the binary data, -1 otherwise
  */
 int
-netaddr_from_binary_prefix(struct netaddr *dst, const void *binary,
-    size_t len, uint8_t addr_type, uint8_t prefix_len) {
-
+netaddr_from_binary_prefix(struct netaddr *dst, const void *binary, size_t len, uint8_t addr_type, uint8_t prefix_len) {
   memset(dst->_addr, 0, sizeof(dst->_addr));
 
   if (addr_type != 0) {
@@ -82,16 +170,16 @@ netaddr_from_binary_prefix(struct netaddr *dst, const void *binary,
         dst->_type = AF_INET;
         break;
       case 6:
-        dst->_type  = AF_MAC48;
+        dst->_type = AF_MAC48;
         break;
       case 8:
-        dst->_type  = AF_EUI64;
+        dst->_type = AF_EUI64;
         break;
       case 16:
-        dst->_type  = AF_INET6;
+        dst->_type = AF_INET6;
         break;
       default:
-        dst->_type  = AF_UNSPEC;
+        dst->_type = AF_UNSPEC;
         if (len > 16) {
           len = 16;
         }
@@ -131,6 +219,66 @@ netaddr_to_binary(void *dst, const struct netaddr *src, size_t len) {
 }
 
 /**
+ * Reads the address and address-type part of an
+ * netaddr_socket into a netaddr object
+ * @param dst netaddr object
+ * @param src netaddr_socket source
+ * @return 0 if successful read binary data, -1 otherwise
+ */
+int
+netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src) {
+  memset(dst->_addr, 0, sizeof(dst->_addr));
+  if (src->std.sa_family == AF_INET) {
+    /* ipv4 */
+    memcpy(dst->_addr, &src->v4.sin_addr, 4);
+    dst->_prefix_len = 32;
+  }
+  else if (src->std.sa_family == AF_INET6) {
+    /* ipv6 */
+    memcpy(dst->_addr, &src->v6.sin6_addr, 16);
+    dst->_prefix_len = 128;
+  }
+  else {
+    /* unknown address type */
+    dst->_type = AF_UNSPEC;
+    return -1;
+  }
+  dst->_type = (uint8_t)src->std.sa_family;
+  return 0;
+}
+
+/**
+ * Writes the address and address-type of a netaddr object
+ * into a netaddr_socket.
+ * @param dst pointer to netaddr_socket
+ * @param src netaddr source
+ * @return 0 if successful read binary data, -1 otherwise
+ */
+int
+netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src) {
+  /* copy address type */
+  dst->std.sa_family = src->_type;
+
+  switch (src->_type) {
+    case AF_INET:
+      /* ipv4 */
+      memcpy(&dst->v4.sin_addr, src->_addr, 4);
+      break;
+    case AF_INET6:
+      /* ipv6 */
+      memcpy(&dst->v6.sin6_addr, src->_addr, 16);
+      break;
+    default:
+      /* unknown address type */
+      return -1;
+  }
+
+  /* copy address type */
+  dst->std.sa_family = src->_type;
+  return 0;
+}
+
+/**
  * Append binary address to autobuf
  * @param abuf pointer to target autobuf
  * @param src pointer to source address
@@ -160,8 +308,7 @@ netaddr_to_autobuf(struct autobuf *abuf, const struct netaddr *src) {
  * @return -1 if an error happened, 0 otherwise
  */
 int
-netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
-    const void *number, size_t num_length) {
+netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask, const void *number, size_t num_length) {
   size_t host_index, number_index;
   uint8_t host_part_length;
   const uint8_t *number_byte;
@@ -184,9 +331,9 @@ netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
   }
 
   /* calculate starting byte in host and number */
-  host_part_length = (host->_prefix_len - netmask->_prefix_len + 7)/8;
+  host_part_length = (host->_prefix_len - netmask->_prefix_len + 7) / 8;
   if (host_part_length > num_length) {
-    host_index = host->_prefix_len/8 - num_length;
+    host_index = host->_prefix_len / 8 - num_length;
     number_index = 0;
   }
   else {
@@ -208,18 +355,176 @@ netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
 }
 
 /**
+ * Creates the network prefix from a host and a netmask. Both host and
+ * netmask must be the same address family.
+ * @param prefix target buffer to write prefix into
+ * @param host host address
+ * @param netmask well formed netmask
+ * @param truncate true if host IP should be truncated
+ * @return -1 if an error happened, 0 otherwise
+ */
+int
+netaddr_create_prefix(
+  struct netaddr *prefix, const struct netaddr *host, const struct netaddr *netmask, bool truncate) {
+  int len, maxlen;
+  if (host->_type != netmask->_type || host->_type == AF_UNSPEC) {
+    return -1;
+  }
+
+  /* get address length */
+  maxlen = netaddr_get_af_maxprefix(host->_type) / 8;
+
+  /* initialize prefix */
+  prefix->_prefix_len = 0;
+  prefix->_type = host->_type;
+
+  if (!truncate) {
+    memcpy(&prefix->_addr[0], &host->_addr[0], 16);
+  }
+
+  for (len = 0; len < maxlen; len++) {
+    if (truncate) {
+      prefix->_addr[len] = host->_addr[len] & netmask->_addr[len];
+    }
+
+    switch (netmask->_addr[len]) {
+      case 255:
+        len++;
+        prefix->_prefix_len += 8;
+        break;
+      case 254:
+        prefix->_prefix_len += 7;
+        return 0;
+      case 252:
+        prefix->_prefix_len += 6;
+        return 0;
+      case 248:
+        prefix->_prefix_len += 5;
+        return 0;
+      case 240:
+        prefix->_prefix_len += 4;
+        return 0;
+      case 224:
+        prefix->_prefix_len += 3;
+        return 0;
+      case 192:
+        prefix->_prefix_len += 2;
+        return 0;
+      case 128:
+        prefix->_prefix_len += 1;
+        return 0;
+      case 0:
+        return 0;
+      default:
+        return -1;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Clear the bits outside of the prefix length of an address
+ * @param dst trucated destination buffer
+ * @param src source IP
+ */
+void
+netaddr_truncate(struct netaddr *dst, const struct netaddr *src) {
+  static uint8_t MASK[] = { 0, 0x80, 0xc0, 0xe0, 0xf0, 0xf8, 0xfc, 0xfe };
+  int byte_prefix, bit_prefix;
+
+  /* calulate byte/bit part of prefix */
+  byte_prefix = src->_prefix_len / 8;
+  bit_prefix = src->_prefix_len & 7;
+
+  if (src != dst) {
+    /* copy type and prefix length */
+    dst->_prefix_len = src->_prefix_len;
+    dst->_type = src->_type;
+
+    /* copy constant octets */
+    memcpy(dst->_addr, src->_addr, byte_prefix);
+  }
+
+  if (bit_prefix) {
+    /* modify bitwise */
+    dst->_addr[byte_prefix] = src->_addr[byte_prefix] & MASK[bit_prefix];
+    byte_prefix++;
+  }
+
+  if (byte_prefix < 16) {
+    /* zero rest of address */
+    memset(&dst->_addr[byte_prefix], 0, 16 - byte_prefix);
+  }
+}
+
+/**
+ * Initialize a netaddr_socket with a netaddr and a port number
+ * @param combined pointer to netaddr_socket to be initialized
+ * @param addr pointer to netaddr source
+ * @param port port number for socket
+ * @param if_index interface index for linklocal ipv6 sockets
+ * @return 0 if successful read binary data, -1 otherwise
+ */
+int
+netaddr_socket_init(union netaddr_socket *combined, const struct netaddr *addr, uint16_t port, unsigned if_index) {
+  /* initialize memory block */
+  memset(combined, 0, sizeof(*combined));
+
+  switch (addr->_type) {
+    case AF_INET:
+      /* ipv4 */
+      memcpy(&combined->v4.sin_addr, addr->_addr, 4);
+      combined->v4.sin_port = htons(port);
+      break;
+    case AF_INET6:
+      /* ipv6 */
+      memcpy(&combined->v6.sin6_addr, addr->_addr, 16);
+      combined->v6.sin6_port = htons(port);
+      combined->v6.sin6_scope_id = if_index;
+      break;
+    default:
+      /* unknown address type */
+      return -1;
+  }
+
+  /* copy address type */
+  combined->std.sa_family = addr->_type;
+  return 0;
+}
+
+/**
+ * @param sock pointer to netaddr_socket
+ * @return port of socket
+ */
+uint16_t
+netaddr_socket_get_port(const union netaddr_socket *sock) {
+  switch (sock->std.sa_family) {
+    case AF_INET:
+      return ntohs(sock->v4.sin_port);
+    case AF_INET6:
+      return ntohs(sock->v6.sin6_port);
+    default:
+      return 0;
+  }
+}
+
+/**
  * Converts a netaddr into a string
  * @param dst target string buffer
  * @param src netaddr source
  * @param forceprefix true if a prefix should be appended even with maximum
  *   prefix length, false if only shorter prefixes should be appended
- * @return pointer to target buffer, NULL if an error happened
+ * @return pointer to target buffer
  */
 const char *
-netaddr_to_prefixstring(struct netaddr_str *dst,
-    const struct netaddr *src, bool forceprefix) {
+netaddr_to_prefixstring(struct netaddr_str *dst, const struct netaddr *src, bool forceprefix) {
+  static const char *NONE = "-";
   const char *result = NULL;
   int maxprefix;
+
+  if (!src) {
+    return strscpy(dst->buf, NONE, sizeof(*dst));
+  }
 
   maxprefix = netaddr_get_maxprefix(src);
   switch (src->_type) {
@@ -230,23 +535,217 @@ netaddr_to_prefixstring(struct netaddr_str *dst,
       result = inet_ntop(AF_INET6, src->_addr, dst->buf, sizeof(*dst));
       break;
     case AF_MAC48:
-      result = _mac_to_string(dst->buf, src->_addr, sizeof(*dst), 6, ':');
+      result = _mac_to_string(dst->buf, sizeof(*dst), src->_addr, 6, ':');
       break;
     case AF_EUI64:
-      result = _mac_to_string(dst->buf, src->_addr, sizeof(*dst), 8, '-');
+      result = _mac_to_string(dst->buf, sizeof(*dst), src->_addr, 8, '-');
+      break;
+    case AF_UUID:
+      result = _uuid_to_string(dst->buf, sizeof(*dst), src->_addr, 16);
       break;
     case AF_UNSPEC:
-      result = strcpy(dst->buf, "-");
-      forceprefix = false;
-      break;
+      /* fall through */
     default:
-      return NULL;
+      return strscpy(dst->buf, NONE, sizeof(*dst));
   }
   if (forceprefix || src->_prefix_len < maxprefix) {
     /* append prefix */
     snprintf(dst->buf + strlen(result), 5, "/%d", src->_prefix_len);
   }
   return result;
+}
+
+/**
+ * Generates a netaddr from a string.
+ * @param dst pointer to netaddr object
+ * @param src pointer to input string
+ * @return -1 if an error happened because of an unknown string,
+ *   0 otherwise
+ */
+int
+netaddr_from_string(struct netaddr *dst, const char *src) {
+  struct netaddr_str buf;
+  unsigned int colon_count, minus_count;
+  int result;
+  int prefix_len;
+  bool has_coloncolon, has_point;
+  bool last_was_colon;
+  char *ptr1, *ptr2, *ptr3;
+  size_t i;
+
+  memset(dst, 0, sizeof(*dst));
+
+  if (strcmp(src, "-") == 0) {
+    /* unspec */
+    netaddr_invalidate(dst);
+    return 0;
+  }
+
+  /* handle string representations of prefixes */
+  for (i = 0; i < ARRAYSIZE(_known_prefixes); i++) {
+    if (strcasecmp(src, _known_prefixes[i].name) == 0) {
+      memcpy(dst, _known_prefixes[i].prefix, sizeof(*dst));
+      return 0;
+    }
+  }
+
+  colon_count = 0;
+  minus_count = 0;
+  has_coloncolon = false;
+  has_point = false;
+
+  last_was_colon = false;
+
+  result = -1;
+  prefix_len = -1;
+
+  /* copy input string in temporary buffer */
+  strscpy(buf.buf, src, sizeof(buf));
+  ptr1 = buf.buf;
+
+  ptr1 = str_trim(ptr1);
+
+  ptr2 = ptr1;
+  while (*ptr2 != 0 && !isspace(*ptr2) && *ptr2 != '/') {
+    switch (*ptr2) {
+      case ':':
+        if (last_was_colon) {
+          has_coloncolon = true;
+        }
+        colon_count++;
+        break;
+
+      case '.':
+        has_point = true;
+        break;
+
+      case '-':
+        minus_count++;
+        break;
+
+      default:
+        break;
+    }
+    last_was_colon = *ptr2++ == ':';
+  }
+
+  if (*ptr2) {
+    /* split strings */
+    while (isspace(*ptr2))
+      *ptr2++ = 0;
+    if (*ptr2 == '/') {
+      *ptr2++ = 0;
+    }
+    while (isspace(*ptr2))
+      *ptr2++ = 0;
+
+    if (*ptr2 == 0) {
+      /* prefixlength is missing */
+      dst->_type = AF_UNSPEC;
+      return -1;
+    }
+
+    /* try to read numeric prefix length */
+    prefix_len = (int)strtoul(ptr2, &ptr3, 10);
+    if (ptr3 && *ptr3) {
+      /* not a numeric prefix length */
+      prefix_len = -1;
+    }
+  }
+
+  /* use dst->prefix_len as storage for maximum prefixlen */
+  if ((colon_count == 5 || minus_count == 5) && (colon_count == 0 || minus_count == 0) && !has_point &&
+      !has_coloncolon) {
+    dst->_type = AF_MAC48;
+    dst->_prefix_len = 48;
+    if (colon_count > 0) {
+      result = _bin_from_hex(dst->_addr, 6, ptr1, ':');
+    }
+    else {
+      result = _bin_from_hex(dst->_addr, 6, ptr1, '-');
+    }
+  }
+  else if (colon_count == 0 && !has_point && minus_count == 7) {
+    dst->_type = AF_EUI64;
+    dst->_prefix_len = 64;
+    dst->_addr[7] = 2;
+    result = _bin_from_hex(dst->_addr, 8, ptr1, '-');
+  }
+  else if (colon_count == 0 && has_point && minus_count == 0) {
+    dst->_type = AF_INET;
+    dst->_prefix_len = 32;
+    result = inet_pton(AF_INET, ptr1, dst->_addr) == 1 ? 0 : -1;
+
+    if (result == 0 && *ptr2 && prefix_len == -1) {
+      /* we need a prefix length, but its not a numerical one */
+      prefix_len = _subnetmask_to_prefixlen(ptr2);
+    }
+  }
+  else if ((has_coloncolon || colon_count == 7) && minus_count == 0) {
+    dst->_type = AF_INET6;
+    dst->_prefix_len = 128;
+    result = inet_pton(AF_INET6, ptr1, dst->_addr) == 1 ? 0 : -1;
+  }
+  else if (minus_count == 4 && colon_count == 0 && !has_point) {
+    dst->_type = AF_UUID;
+    dst->_prefix_len = 128;
+    result = _uuid_from_string(dst->_addr, sizeof(dst->_addr), ptr1);
+  }
+
+  /* stop if an error happened */
+  if (result) {
+    dst->_type = AF_UNSPEC;
+    return -1;
+  }
+
+  if (*ptr2) {
+    if (prefix_len < 0 || prefix_len > dst->_prefix_len) {
+      /* prefix is too long */
+      dst->_type = AF_UNSPEC;
+      return -1;
+    }
+
+    /* store real prefix length */
+    dst->_prefix_len = (uint8_t)prefix_len;
+  }
+  return 0;
+}
+
+/**
+ * Converts a netaddr_socket into a string
+ * @param dst target string buffer
+ * @param src netaddr_socket source
+ * @return pointer to target buffer, NULL if an error happened
+ */
+const char *
+netaddr_socket_to_string(struct netaddr_str *dst, const union netaddr_socket *src) {
+  struct netaddr_str buf;
+
+  if (src->std.sa_family == AF_INET) {
+    snprintf(dst->buf, sizeof(*dst), "%s:%d", inet_ntop(AF_INET, &src->v4.sin_addr, buf.buf, sizeof(buf)),
+      ntohs(src->v4.sin_port));
+  }
+  else if (src->std.sa_family == AF_INET6) {
+#if 0
+    if (src->v6.sin6_scope_id) {
+      char scope_buf[IF_NAMESIZE];
+
+      snprintf(dst->buf, sizeof(*dst), "[%s]:%d%%%s", inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
+        ntohs(src->v6.sin6_port), if_indextoname(src->v6.sin6_scope_id, scope_buf));
+    }
+    else {
+#endif
+      snprintf(dst->buf, sizeof(*dst), "[%s]:%d", inet_ntop(AF_INET6, &src->v6.sin6_addr, buf.buf, sizeof(buf)),
+        ntohs(src->v6.sin6_port));
+#if 0
+    }
+#endif
+  }
+  else {
+    snprintf(dst->buf, sizeof(*dst), "\"Unknown socket type: %d\"", src->std.sa_family);
+  }
+
+  return dst->buf;
 }
 
 /**
@@ -265,6 +764,51 @@ netaddr_avlcmp(const void *k1, const void *k2) {
 }
 
 /**
+ * Compares two netaddr sockets.
+ *
+ * This function is compatible with the avl comparator
+ * prototype.
+ * @param k1 address 1
+ * @param k2 address 2
+ * @return >0 if k1>k2, <0 if k1<k2, 0 otherwise
+ */
+int
+netaddr_socket_avlcmp(const void *k1, const void *k2) {
+  return netaddr_socket_cmp(k1, k2);
+}
+
+/**
+ * Compares an netaddr object with the address part of
+ * a netaddr_socket.
+ * @param a1 address
+ * @param a2 socket
+ * @return >0 if k1>k2, <0 if k1<k2, 0 otherwise
+ */
+int
+netaddr_cmp_to_socket(const struct netaddr *a1, const union netaddr_socket *a2) {
+  int result = 0;
+
+  result = (int)a1->_type - (int)a2->std.sa_family;
+  if (result) {
+    return result;
+  }
+
+  if (a1->_type == AF_INET) {
+    result = memcmp(a1->_addr, &a2->v4.sin_addr, 4);
+  }
+  else if (a1->_type == AF_INET6) {
+    /* ipv6 */
+    result = memcmp(a1->_addr, &a2->v6.sin6_addr, 16);
+  }
+
+  if (result) {
+    return result;
+  }
+
+  return (int)a1->_prefix_len - (a1->_type == AF_INET ? 32 : 128);
+}
+
+/**
  * Calculates if a binary address is equals to a netaddr one.
  * @param addr netaddr pointer
  * @param bin pointer to binary address
@@ -274,8 +818,7 @@ netaddr_avlcmp(const void *k1, const void *k2) {
  * @return true if matches, false otherwise
  */
 bool
-netaddr_isequal_binary(const struct netaddr *addr,
-    const void *bin, size_t len, uint16_t af, uint8_t prefix_len) {
+netaddr_isequal_binary(const struct netaddr *addr, const void *bin, size_t len, uint16_t af, uint8_t prefix_len) {
   uint32_t addr_len;
 
   if (addr->_type != af || addr->_prefix_len != prefix_len) {
@@ -299,10 +842,8 @@ netaddr_isequal_binary(const struct netaddr *addr,
  * @return true if part of the prefix, false otherwise
  */
 bool
-netaddr_binary_is_in_subnet(const struct netaddr *subnet,
-    const void *bin, size_t len, uint8_t af_family) {
-  if (subnet->_type != af_family
-      || netaddr_get_maxprefix(subnet) != len * 8) {
+netaddr_binary_is_in_subnet(const struct netaddr *subnet, const void *bin, size_t len, uint8_t af_family) {
+  if (subnet->_type != af_family || netaddr_get_maxprefix(subnet) != len * 8) {
     return false;
   }
   return _binary_is_in_subnet(subnet, bin);
@@ -316,8 +857,7 @@ netaddr_binary_is_in_subnet(const struct netaddr *subnet,
  * @return true if addr is part of subnet, false otherwise
  */
 bool
-netaddr_is_in_subnet(const struct netaddr *subnet,
-    const struct netaddr *addr) {
+netaddr_is_in_subnet(const struct netaddr *subnet, const struct netaddr *addr) {
   if (subnet->_type != addr->_type) {
     return false;
   }
@@ -349,18 +889,93 @@ netaddr_get_af_maxprefix(uint32_t af_type) {
   }
 }
 
+#ifdef WIN32
+/**
+ * Helper function for windows
+ * @param dst
+ * @param bin
+ * @param dst_size
+ * @param bin_size
+ * @param separator
+ * @return
+ */
+const char *
+inet_ntop(int af, const void *src, char *dst, socklen_t cnt) {
+  if (af == AF_INET) {
+    struct sockaddr_in in;
+    memset(&in, 0, sizeof(in));
+    in.sin_family = AF_INET;
+    memcpy(&in.sin_addr, src, sizeof(struct in_addr));
+    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in), dst, cnt, NULL, 0, NI_NUMERICHOST);
+    return dst;
+  }
+  else if (af == AF_INET6) {
+    struct sockaddr_in6 in;
+    memset(&in, 0, sizeof(in));
+    in.sin6_family = AF_INET6;
+    memcpy(&in.sin6_addr, src, sizeof(struct in_addr6));
+    getnameinfo((struct sockaddr *)&in, sizeof(struct sockaddr_in6), dst, cnt, NULL, 0, NI_NUMERICHOST);
+    return dst;
+  }
+  return NULL;
+}
+
+/**
+ * Helper function for windows
+ * @param dst
+ * @param bin
+ * @param dst_size
+ * @param bin_size
+ * @param separator
+ * @return
+ */
+int
+inet_pton(int af, const char *src, void *dst) {
+  struct addrinfo hints, *res;
+  union netaddr_socket *sock;
+
+  if (af != AF_INET && af != AF_INET6) {
+    return -1;
+  }
+
+  memset(&hints, 0, sizeof(struct addrinfo));
+  hints.ai_family = af;
+  hints.ai_flags = AI_NUMERICHOST;
+
+  if (getaddrinfo(src, NULL, &hints, &res) != 0) {
+    return -1;
+  }
+
+  if (res == NULL) {
+    return 0;
+  }
+
+  sock = (union netaddr_socket *)res->ai_addr;
+  if (af == AF_INET) {
+    memcpy(dst, &sock->v4.sin_addr, 4);
+  }
+  else {
+    memcpy(dst, &sock->v6.sin6_addr, 16);
+  }
+
+  freeaddrinfo(res);
+  return 1;
+}
+
+#endif
+
 /**
  * Converts a binary mac address into a string representation
  * @param dst pointer to target string buffer
- * @param bin pointer to binary source buffer
  * @param dst_size size of string buffer
+ * @param bin pointer to binary source buffer
  * @param bin_size size of binary buffer
- * @param separator character for separating hexadecimal octets
+ * @param separator character for separating hexadecimal octets,
+ *     0 for no separator
  * @return pointer to target buffer, NULL if an error happened
  */
 static char *
-_mac_to_string(char *dst, const void *bin, size_t dst_size,
-    size_t bin_size, char separator) {
+_mac_to_string(char *dst, size_t dst_size, const void *bin, size_t bin_size, char separator) {
   static const char hex[] = "0123456789abcdef";
   char *last_separator, *_dst;
   const uint8_t *_bin;
@@ -381,14 +996,17 @@ _mac_to_string(char *dst, const void *bin, size_t dst_size,
     last_separator = _dst;
 
     /* write separator */
-    *_dst++ = separator;
+    if (separator) {
+      *_dst++ = separator;
+      dst_size--;
+    }
 
     /* advance source pointer and decrease remaining length of buffer*/
     _bin++;
     bin_size--;
 
     /* calculate remaining destination size */
-    dst_size-=3;
+    dst_size -= 2;
   }
 
   *last_separator = 0;
@@ -396,15 +1014,57 @@ _mac_to_string(char *dst, const void *bin, size_t dst_size,
 }
 
 /**
- * Convert a string mac address into a binary representation
+ * Convert a binary UUID into its string representation
+ * @param dst pointer to target string buffer
+ * @param dst_size size of string buffer
+ * @param src pointer to binary source buffer
+ * @param src_size size of binary buffer
+ * @return pointer to target buffer, NULL if an error happened
+ */
+static char *
+_uuid_to_string(char *dst, size_t dst_size, const void *src, size_t src_size) {
+  static const size_t max_group_len[5] = { 8, 4, 4, 4, 12 };
+  const char *_src;
+  char *_dst;
+  size_t i;
+
+  if (src_size != 16) {
+    return NULL;
+  }
+  if (dst_size < 32 + 4 + 1) {
+    return NULL;
+  }
+
+  _src = src;
+  _dst = dst;
+  for (i = 0; i < ARRAYSIZE(max_group_len); i++) {
+    if (!_mac_to_string(_dst, dst_size, _src, max_group_len[i] / 2, 0)) {
+      return NULL;
+    }
+
+    _src += (max_group_len[i] / 2);
+    _dst += (max_group_len[i]);
+    dst_size -= max_group_len[i];
+
+    if (i < ARRAYSIZE(max_group_len) - 1) {
+      *_dst++ = '-';
+      dst_size--;
+    }
+  }
+  return dst;
+}
+
+/**
+ * Convert a hex string (with optional separators) into a binary representation
  * @param bin pointer to target binary buffer
  * @param bin_size pointer to size of target buffer
  * @param src pointer to source string
- * @param separator character used to separate octets in source string
- * @return 0 if sucessfully converted, -1 otherwise
+ * @param separator character used to separate octets in source string,
+ *     0 for no separator
+ * @return number of bytes left in target buffer, -1 if an error happened
  */
 static int
-_mac_from_string(void *bin, size_t bin_size, const char *src, char separator) {
+_bin_from_hex(void *bin, size_t bin_size, const char *src, char separator) {
   uint8_t *_bin;
   int num, digit_2;
 
@@ -420,18 +1080,72 @@ _mac_from_string(void *bin, size_t bin_size, const char *src, char separator) {
       num = (num << 4) + digit_2;
       src++;
     }
-    *_bin++ = (uint8_t) num;
+    *_bin++ = (uint8_t)num;
 
     bin_size--;
 
     if (*src == 0) {
-      return bin_size ? -1 : 0;
+      return bin_size;
     }
-    if (*src++ != separator) {
-      return -1;
+    if (separator) {
+      if (*src++ != separator) {
+        return -1;
+      }
     }
   }
   return -1;
+}
+
+/**
+ * Convert a string UUID into the binary (16 byte) representation
+ * @param bin target buffer
+ * @param bin_size size of target buffer
+ * @param src UUID string
+ * @return -1 if an error happened, 0 otherwise
+ */
+static int
+_uuid_from_string(void *bin, size_t bin_size, const char *src) {
+  static const size_t max_group_len[5] = { 8, 4, 4, 4, 12 };
+  char buffer[32 + 4 + 1];
+  char *current_group, *next_group, *_bin;
+  size_t i;
+
+  if (bin_size < 16) {
+    return -1;
+  }
+  if (strlen(src) > 32 + 4) {
+    return -1;
+  }
+
+  strscpy(buffer, src, sizeof(buffer));
+
+  _bin = bin;
+  current_group = buffer;
+  for (i = 0; i < ARRAYSIZE(max_group_len); i++) {
+    next_group = strchr(current_group, '-');
+    if (next_group) {
+      /* zero terminate current group */
+      *next_group++ = 0;
+    }
+    else if (i != ARRAYSIZE(max_group_len) - 1) {
+      /* not enough components */
+      return -1;
+    }
+
+    /* check length */
+    if (strlen(current_group) != max_group_len[i]) {
+      return -1;
+    }
+
+    /* parse data, we expect a precise number of hex-numbers */
+    if (_bin_from_hex(_bin, max_group_len[i] / 2, current_group, 0)) {
+      return -1;
+    }
+
+    current_group = next_group;
+    _bin = _bin + max_group_len[i] / 2;
+  }
+  return 0;
 }
 
 /**
@@ -488,7 +1202,7 @@ _subnetmask_to_prefixlen(const char *src) {
  * Calculates if a binary address is part of a netaddr prefix.
  * It will assume that the length of the binary address and its
  * address family makes sense.
- * @param addr netaddr prefix
+ * @param subnet netaddr prefix
  * @param bin pointer to binary address
  * @return true if part of the prefix, false otherwise
  */
@@ -510,8 +1224,7 @@ _binary_is_in_subnet(const struct netaddr *subnet, const void *bin) {
 
   /* compare bits if necessary */
   if (bit_length != 0) {
-    return (subnet->_addr[byte_length] >> (8 - bit_length))
-        == (_bin[byte_length] >> (8 - bit_length));
+    return (subnet->_addr[byte_length] >> (8 - bit_length)) == (_bin[byte_length] >> (8 - bit_length));
   }
   return true;
 }

--- a/sys/oonf_api/common/netaddr.h
+++ b/sys/oonf_api/common/netaddr.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,54 +39,96 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef NETADDR_H_
 #define NETADDR_H_
 
-
+#ifndef _WIN32
 #include <arpa/inet.h>
+#ifndef RIOT_VERSION
+#include <net/if.h>
+#include <netinet/if_ether.h>
+#include <netinet/ip.h>
+#endif
+#else
+#include <winsock2.h>
+#include <ws2tcpip.h>
 
-#include <assert.h>
+#define IF_NAMESIZE 16
+#endif
+
 #include <string.h>
 
 #include "common/autobuf.h"
+#include "common/common_types.h"
 
-/* Pseude address families for mac/eui64 */
-enum {
+enum
+{
+  /*! address family for 48-bit mac address */
   AF_MAC48 = AF_MAX + 1,
+
+  /*! address family for 64-bit EUI-64 address */
   AF_EUI64 = AF_MAX + 2,
+
+  /*! universal unique identifier (UUID) */
+  AF_UUID = AF_MAX + 3,
 };
 
-/* maximum number of octets for address */
-enum { NETADDR_MAX_LENGTH = 16 };
+enum
+{
+  /*! maximum length of a network address in octets */
+  NETADDR_MAX_LENGTH = 16
+};
 
-/* text names for defining netaddr prefixes */
-#define NETADDR_STR_ANY4       "any4"
-#define NETADDR_STR_ANY6       "any6"
+/*! text name for IPv4_ANY prefix */
+#define NETADDR_STR_ANY4 "any4"
+
+/*! text name for IPv6 ANY prefix */
+#define NETADDR_STR_ANY6 "any6"
+
+/*! text name for IPv4 linklocal prefix */
 #define NETADDR_STR_LINKLOCAL4 "linklocal4"
+
+/*! text name for IPv6 linklocal prefix */
 #define NETADDR_STR_LINKLOCAL6 "linklocal6"
-#define NETADDR_STR_ULA        "ula"
+
+/*! text name for IPv6 unique local prefix */
+#define NETADDR_STR_ULA "ula"
 
 /**
  * Representation of an address including address type
  * At the moment we support AF_INET, AF_INET6 and AF_MAC48
  */
 struct netaddr {
-  /* 16 bytes of memory for address */
+  /*! 16 bytes of memory for address */
   uint8_t _addr[NETADDR_MAX_LENGTH];
 
-  /* address type */
+  /*! address type */
   uint8_t _type;
 
-  /* address prefix length */
+  /*! address prefix length */
   uint8_t _prefix_len;
 };
 
 /**
- * Buffer for writing string representation of netaddr
- * and netaddr_socket objects
+ * Representation of a sockaddr object. Allows access
+ * to all variants without casting and compiler warnings.
  */
-struct netaddr_str {
-  char buf[INET6_ADDRSTRLEN+16];
+union netaddr_socket {
+  /*! IPv4 sockaddr */
+  struct sockaddr_in v4;
+
+  /*! IPv6 sockaddr */
+  struct sockaddr_in6 v6;
+
+  /*! generic sockaddr */
+  struct sockaddr std;
+
+  /*! storage object for sockaddr */
+  struct sockaddr_storage storage;
 };
 
 /**
@@ -95,7 +137,8 @@ struct netaddr_str {
  * INET_ADDRSTRLEN and INET6_ADDRSTRLEN have been defined
  * in netinet/in.h, which has been included by this file
  */
-enum {
+enum
+{
   MAC48_ADDRSTRLEN = 18,
   MAC48_PREFIXSTRLEN = MAC48_ADDRSTRLEN + 3,
   EUI64_ADDRSTRLEN = 24,
@@ -104,42 +147,126 @@ enum {
   INET6_PREFIXSTRLEN = INET6_ADDRSTRLEN + 4,
 };
 
-int netaddr_from_binary_prefix(struct netaddr *dst,
-    const void *binary, size_t len, uint8_t addr_type, uint8_t prefix_len);
-int netaddr_to_binary(void *dst, const struct netaddr *src, size_t len);
-int netaddr_to_autobuf(struct autobuf *, const struct netaddr *src);
-int netaddr_create_host_bin(struct netaddr *host, const struct netaddr *netmask,
-    const void *number, size_t num_length);
-const char *netaddr_to_prefixstring(
-    struct netaddr_str *dst, const struct netaddr *src, bool forceprefix);
+/**
+ * Buffer for writing string representation of netaddr
+ * and netaddr_socket objects
+ */
+struct netaddr_str {
+  /*! buffer for maximum length netaddr string representation */
+  char buf[INET6_ADDRSTRLEN + 16];
+};
 
-bool netaddr_isequal_binary(const struct netaddr *addr,
-    const void *bin, size_t len, uint16_t af, uint8_t prefix_len);
-bool netaddr_is_in_subnet(const struct netaddr *subnet,
-    const struct netaddr *addr);
-bool netaddr_binary_is_in_subnet(const struct netaddr *subnet,
-    const void *bin, size_t len, uint8_t af_family);
+EXPORT extern const struct netaddr NETADDR_UNSPEC;
 
-uint8_t netaddr_get_af_maxprefix(const uint32_t);
+EXPORT extern const struct netaddr NETADDR_IPV4_ANY;
+EXPORT extern const struct netaddr NETADDR_IPV4_BINDTO_ANY;
+EXPORT extern const struct netaddr NETADDR_IPV4_MULTICAST;
+EXPORT extern const struct netaddr NETADDR_IPV4_LINKLOCAL;
+EXPORT extern const struct netaddr NETADDR_IPV4_LOOPBACK_NET;
 
-int netaddr_avlcmp(const void *, const void *);
+EXPORT extern const struct netaddr NETADDR_IPV6_ANY;
+EXPORT extern const struct netaddr NETADDR_IPV6_BINDTO_ANY;
+EXPORT extern const struct netaddr NETADDR_IPV6_MULTICAST;
+EXPORT extern const struct netaddr NETADDR_IPV6_LINKLOCAL;
+EXPORT extern const struct netaddr NETADDR_IPV6_ULA;
+EXPORT extern const struct netaddr NETADDR_IPV6_GLOBAL;
+EXPORT extern const struct netaddr NETADDR_IPV6_IPV4COMPATIBLE;
+EXPORT extern const struct netaddr NETADDR_IPV6_IPV4MAPPED;
+EXPORT extern const struct netaddr NETADDR_IPV6_LOOPBACK;
+EXPORT extern const struct netaddr NETADDR_MAC48_BROADCAST;
+
+EXPORT extern const union netaddr_socket NETADDR_SOCKET_IPV4_ANY;
+EXPORT extern const union netaddr_socket NETADDR_SOCKET_IPV6_ANY;
+
+EXPORT int netaddr_from_binary_prefix(
+  struct netaddr *dst, const void *binary, size_t len, uint8_t addr_type, uint8_t prefix_len);
+EXPORT int netaddr_to_binary(void *dst, const struct netaddr *src, size_t len);
+EXPORT int netaddr_from_socket(struct netaddr *dst, const union netaddr_socket *src);
+EXPORT int netaddr_to_socket(union netaddr_socket *dst, const struct netaddr *src);
+EXPORT int netaddr_to_autobuf(struct autobuf *, const struct netaddr *src);
+EXPORT int netaddr_create_host_bin(
+  struct netaddr *host, const struct netaddr *netmask, const void *number, size_t num_length);
+EXPORT int netaddr_create_prefix(
+  struct netaddr *prefix, const struct netaddr *host, const struct netaddr *netmask, bool truncate);
+EXPORT void netaddr_truncate(struct netaddr *dst, const struct netaddr *src);
+
+EXPORT int netaddr_socket_init(
+  union netaddr_socket *combined, const struct netaddr *addr, uint16_t port, unsigned if_index);
+EXPORT uint16_t netaddr_socket_get_port(const union netaddr_socket *sock);
+EXPORT const char *netaddr_to_prefixstring(struct netaddr_str *dst, const struct netaddr *src, bool forceprefix);
+EXPORT int netaddr_from_string(struct netaddr *, const char *) __attribute__((warn_unused_result));
+EXPORT const char *netaddr_socket_to_string(struct netaddr_str *, const union netaddr_socket *);
+
+EXPORT int netaddr_cmp_to_socket(const struct netaddr *, const union netaddr_socket *);
+EXPORT bool netaddr_isequal_binary(
+  const struct netaddr *addr, const void *bin, size_t len, uint16_t af, uint8_t prefix_len);
+EXPORT bool netaddr_is_in_subnet(const struct netaddr *subnet, const struct netaddr *addr);
+EXPORT bool netaddr_binary_is_in_subnet(const struct netaddr *subnet, const void *bin, size_t len, uint8_t af_family);
+
+EXPORT uint8_t netaddr_get_af_maxprefix(const uint32_t);
+
+EXPORT int netaddr_avlcmp(const void *, const void *);
+EXPORT int netaddr_socket_avlcmp(const void *, const void *);
+
+#ifdef WIN32
+EXPORT const char *inet_ntop(int af, const void *src, char *dst, int cnt);
+EXPORT int inet_pton(int af, const char *cp, void *buf);
+#endif
 
 /**
  * Sets the address type of a netaddr object to AF_UNSPEC
  * @param addr netaddr object
  */
-static inline void
+static INLINE void
 netaddr_invalidate(struct netaddr *addr) {
   memset(addr, 0, sizeof(*addr));
 }
+
+/**
+ * Sets the address type of a netaddr object to AF_UNSPEC
+ * @param sock netaddr socket object
+ */
+static INLINE void
+netaddr_socket_invalidate(union netaddr_socket *sock) {
+  memset(sock, 0, sizeof(*sock));
+}
+
+/**
+ * @param addr netaddr object
+ * @return true if address is AF_UNSPEC, false otherwise
+ */
+static INLINE bool
+netaddr_is_unspec(const struct netaddr *addr) {
+  return addr->_type == AF_UNSPEC;
+}
+
+/**
+ * @param sock netaddr socket object
+ * @return true if address is AF_UNSPEC, false otherwise
+ */
+static INLINE bool
+netaddr_socket_is_unspec(const union netaddr_socket *sock) {
+  return sock->std.sa_family == AF_UNSPEC;
+}
+
 /**
  * Calculates the maximum prefix length of an address type
  * @param addr netaddr object
  * @return prefix length, 0 if unknown address family
  */
-static inline uint8_t
+static INLINE uint8_t
 netaddr_get_maxprefix(const struct netaddr *addr) {
   return netaddr_get_af_maxprefix(addr->_type);
+}
+
+/**
+ * Check if an address has the maximum prefix length
+ * @param addr netaddr object
+ * @return true if prefix length is maximum, false otherwise
+ */
+static INLINE bool
+netaddr_is_host(const struct netaddr *addr) {
+  return netaddr_get_maxprefix(addr) == addr->_prefix_len;
 }
 
 /**
@@ -149,7 +276,7 @@ netaddr_get_maxprefix(const struct netaddr *addr) {
  * @param src netaddr source
  * @return pointer to target buffer, NULL if an error happened
  */
-static inline const char *
+static INLINE const char *
 netaddr_to_string(struct netaddr_str *dst, const struct netaddr *src) {
   return netaddr_to_prefixstring(dst, src, false);
 }
@@ -163,11 +290,22 @@ netaddr_to_string(struct netaddr_str *dst, const struct netaddr *src) {
  * @param host_number postfix of result
  * @return -1 if an error happened, 0 otherwise
  */
-static inline int
-netaddr_create_host(struct netaddr *host, const struct netaddr *netmask,
-    const struct netaddr *host_number) {
-  return netaddr_create_host_bin(host, netmask, host_number->_addr,
-      netaddr_get_maxprefix(host_number));
+static INLINE int
+netaddr_create_host(struct netaddr *host, const struct netaddr *netmask, const struct netaddr *host_number) {
+  return netaddr_create_host_bin(host, netmask, host_number->_addr, netaddr_get_maxprefix(host_number) / 8);
+}
+
+/**
+ * Embed an IPv4 address into an IPv6 IPv4-compatible address
+ * @param dst target IPv6 address
+ * @param src source IPv4 address
+ */
+static INLINE void
+netaddr_embed_ipv4_compatible(struct netaddr *dst, const struct netaddr *src) {
+  memcpy(&dst->_addr[0], &NETADDR_IPV6_IPV4COMPATIBLE._addr[0], 12);
+  memcpy(&dst->_addr[12], &src->_addr[0], 4);
+  dst->_type = AF_INET6;
+  dst->_prefix_len = src->_prefix_len + 96;
 }
 
 /**
@@ -175,7 +313,7 @@ netaddr_create_host(struct netaddr *host, const struct netaddr *netmask,
  * @param dst target IPv4 address
  * @param src source IPv6 address
  */
-static inline void
+static INLINE void
 netaddr_extract_ipv4_compatible(struct netaddr *dst, const struct netaddr *src) {
   memcpy(&dst->_addr[0], &src->_addr[12], 4);
   memset(&dst->_addr[4], 0, 12);
@@ -192,9 +330,8 @@ netaddr_extract_ipv4_compatible(struct netaddr *dst, const struct netaddr *src) 
  *   0 for autodetection based on length
  * @return 0 if successful read binary data, -1 otherwise
  */
-static inline int
-netaddr_from_binary(struct netaddr *dst, const void *binary,
-    size_t len, uint8_t addr_type) {
+static INLINE int
+netaddr_from_binary(struct netaddr *dst, const void *binary, size_t len, uint8_t addr_type) {
   return netaddr_from_binary_prefix(dst, binary, len, addr_type, 255);
 }
 
@@ -205,16 +342,27 @@ netaddr_from_binary(struct netaddr *dst, const void *binary,
  * @param a2 address 2
  * @return >0 if a1>a2, <0 if a1<a2, 0 otherwise
  */
-static inline int
+static INLINE int
 netaddr_cmp(const struct netaddr *a1, const struct netaddr *a2) {
   return memcmp(a1, a2, sizeof(*a1));
+}
+
+/**
+ * Compares two sockets.
+ * @param s1 socket address port 1
+ * @param s2 socket address/port 2
+ * @return >0 if s1>s2, <0 if s1<s2, 0 otherwise
+ */
+static INLINE int
+netaddr_socket_cmp(const union netaddr_socket *s1, const union netaddr_socket *s2) {
+  return memcmp(s1, s2, sizeof(*s1));
 }
 
 /**
  * @param n pointer to netaddr
  * @return pointer to start of binary address
  */
-static inline const void *
+static INLINE const void *
 netaddr_get_binptr(const struct netaddr *n) {
   return &n->_addr[0];
 }
@@ -223,7 +371,7 @@ netaddr_get_binptr(const struct netaddr *n) {
  * @param n pointer to netaddr
  * @return number of bytes of binary address
  */
-static inline size_t
+static INLINE size_t
 netaddr_get_binlength(const struct netaddr *n) {
   return netaddr_get_maxprefix(n) >> 3;
 }
@@ -232,7 +380,7 @@ netaddr_get_binlength(const struct netaddr *n) {
  * @param n pointer to netaddr
  * @return address family
  */
-static inline uint8_t
+static INLINE uint8_t
 netaddr_get_address_family(const struct netaddr *n) {
   return n->_type;
 }
@@ -241,18 +389,27 @@ netaddr_get_address_family(const struct netaddr *n) {
  * @param n pointer to netaddr
  * @return prefix length
  */
-static inline uint8_t
+static INLINE uint8_t
 netaddr_get_prefix_length(const struct netaddr *n) {
   return n->_prefix_len;
 }
 
 /**
  * @param n pointer to netaddr
- * @param prefix_length new prefix length
+ * @param prefix_len new prefix length
  */
-static inline void
+static INLINE void
 netaddr_set_prefix_length(struct netaddr *n, uint8_t prefix_len) {
   n->_prefix_len = prefix_len;
+}
+
+/**
+ * @param s pointer to netaddr socket
+ * @return address family of socket
+ */
+static INLINE sa_family_t
+netaddr_socket_get_addressfamily(const union netaddr_socket *s) {
+  return s->std.sa_family;
 }
 
 #endif /* NETADDR_H_ */

--- a/sys/oonf_api/common/string.c
+++ b/sys/oonf_api/common/string.c
@@ -1,0 +1,496 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common/string.h"
+
+/**
+ * @param size minimum size of block
+ * @return rounded up block size of STRARRAY_BLOCKSIZE
+ */
+static INLINE size_t
+STRARRAY_MEMSIZE(const size_t size) {
+  return (size + STRARRAY_BLOCKSIZE - 1) & (~(STRARRAY_BLOCKSIZE - 1));
+}
+
+/**
+ * A safer version of strncpy that ensures that the
+ * destination string will be null-terminated if its
+ * length is greater than 0.
+ * @param dest target string buffer
+ * @param src source string buffer
+ * @param size size of target buffer
+ * @return pointer to target buffer
+ */
+char *
+strscpy(char *dest, const char *src, size_t size) {
+  if (dest == NULL || src == NULL || size == 0) {
+    return dest;
+  }
+
+  /* src does not need to be null terminated */
+  strncpy(dest, src, size - 1);
+  dest[size - 1] = 0;
+
+  return dest;
+}
+
+/**
+ * A safer version of strncat that ensures that
+ * the target buffer will be null-terminated if
+ * its size is greater than zero.
+ *
+ * If the target buffer is already full, it will
+ * not be changed.
+ * @param dest target string buffer
+ * @param src source string buffer
+ * @param size size of target buffer
+ * @return pointer to target buffer
+ */
+char *
+strscat(char *dest, const char *src, size_t size) {
+  size_t l;
+
+  if (dest == NULL || src == NULL || size == 0 || *src == 0) {
+    return dest;
+  }
+
+  l = strlen(dest);
+  if (l < size) {
+    strscpy(dest + l, src, size - l);
+  }
+  return dest;
+}
+
+/**
+ * Removes leading and trailing whitespaces from a string.
+ * @param ptr input string to be modified string-pointer
+ * @return pointer to first non-whitespace character in string
+ */
+char *
+str_trim(char *ptr) {
+  size_t len;
+
+  if (!ptr) {
+    return NULL;
+  }
+
+  /* skip leading whitespaces */
+  while (isspace(*ptr)) {
+    ptr++;
+  }
+
+  /* get end of string */
+  len = strlen(ptr);
+  if (len) {
+    /* remove trailing whitespaces */
+    while (--len > 0 && isspace(ptr[len])) {
+      ptr[len] = 0;
+    }
+  }
+  return ptr;
+}
+
+/**
+ * Check if a string starts with a certain word. The function
+ * is not case sensitive and does NOT modify the input strings.
+ * @param buffer pointer to string
+ * @param word pointer to the word
+ * @return pointer to the string behind the word, NULL if no match
+ */
+const char *
+str_hasnextword(const char *buffer, const char *word) {
+  /* sanity check */
+  if (buffer == NULL) {
+    return NULL;
+  }
+
+  /* skip whitespace prefix */
+  while (isblank(*buffer)) {
+    buffer++;
+  }
+
+  while (*word != 0 && *buffer != 0 && !isblank(*buffer) && tolower(*word) == tolower(*buffer)) {
+    word++;
+    buffer++;
+  }
+
+  /* complete match ? */
+  if (*word == 0 && (*buffer == 0 || isblank(*buffer))) {
+    while (isblank(*buffer)) {
+      buffer++;
+    }
+    return buffer;
+  }
+  return NULL;
+}
+
+/**
+ * Copies the next word of a constant stringbuffer into
+ * a second buffer.
+ * @param dst pointer to target buffer
+ * @param src constant source buffer
+ * @param len maximum length of copied data
+ * @return pointer to next word behind the copied word
+ */
+const char *
+str_cpynextword(char *dst, const char *src, size_t len) {
+  size_t i;
+
+  /* sanity check */
+  if (src == NULL) {
+    *dst = 0;
+    return NULL;
+  }
+
+  /* skip whitespace prefix */
+  while (isblank(*src)) {
+    src++;
+  }
+
+  /* copy next word */
+  i = 0;
+  while (*src != 0 && !isblank(*src) && i < len - 1) {
+    dst[i++] = *src++;
+  }
+
+  /* terminate */
+  dst[i] = 0;
+
+  /* skip ahead in src */
+  while (isblank(*src)) {
+    src++;
+  }
+
+  if (*src) {
+    /* return next word */
+    return src;
+  }
+
+  /* end of src */
+  return NULL;
+}
+
+/**
+ * Skips the next word of a constant stringbuffer.
+ * @param src constant source buffer
+ * @return pointer to next word behind the skipped word
+ */
+const char *
+str_skipnextword(const char *src) {
+  /* sanity check */
+  if (src == NULL) {
+    return NULL;
+  }
+
+  /* skip whitespace prefix */
+  while (isblank(*src)) {
+    src++;
+  }
+
+  /* copy next word */
+  while (*src != 0 && !isblank(*src)) {
+    src++;
+  }
+
+  /* skip ahead in src */
+  while (isblank(*src)) {
+    src++;
+  }
+
+  if (*src) {
+    /* return next word */
+    return src;
+  }
+
+  /* end of src */
+  return NULL;
+}
+
+/**
+ * @param src pointer to source string
+ * @return number of non-whitespace words separated by whitespaces in string
+ */
+size_t
+str_countwords(const char *src) {
+  size_t count = 0;
+
+  /* sanity check */
+  if (src != NULL) {
+    /* skip whitespace prefix */
+    while (isblank(*src)) {
+      src++;
+    }
+
+    while (src != NULL && *src != 0) {
+      count++;
+
+      src = str_skipnextword(src);
+    }
+  }
+  return count;
+}
+
+/**
+ * Printable is defined as all ascii characters >= 32 except
+ * 127 and 255.
+ * @param value stringpointer
+ * @return true if string only contains printable characters,
+ *   false otherwise
+ */
+bool
+str_is_printable(const char *value) {
+  const unsigned char *_value;
+
+  _value = (const unsigned char *)value;
+
+  while (*_value) {
+    if (!str_char_is_printable(*_value)) {
+      return false;
+    }
+    _value++;
+  }
+  return true;
+}
+
+/**
+ * Copy a string array into another array. This overwrites
+ * all data in the original array.
+ * @param dst destination array
+ * @param src source array
+ * @return 0 if array was copied, -1 if an error happened
+ */
+int
+strarray_copy(struct strarray *dst, const struct strarray *src) {
+  char *ptr;
+  size_t block;
+  if (src->value == NULL || src->length == 0) {
+    memset(dst, 0, sizeof(*dst));
+    return 0;
+  }
+
+  block = STRARRAY_MEMSIZE(src->length);
+  ptr = realloc(dst->value, block);
+  if (!ptr) {
+    return -1;
+  }
+
+  memcpy(ptr, src->value, src->length);
+  memset(ptr + src->length, 0, block - src->length);
+  dst->length = src->length;
+  dst->value = ptr;
+  return 0;
+}
+
+/**
+ * Appends a string to an existing string array. Only use this
+ * if the string-array value has been allocated with malloc/calloc.
+ * @param array pointer to string array object
+ * @param string pointer to string to append
+ * @return 0 if string was appended, -1 if an error happened
+ */
+int
+strarray_append(struct strarray *array, const char *string) {
+  size_t length, new_length;
+  char *ptr;
+
+  length = strlen(string) + 1;
+
+  new_length = array->length + length;
+  ptr = realloc(array->value, STRARRAY_MEMSIZE(new_length));
+  if (ptr == NULL) {
+    return -1;
+  }
+
+  memcpy(ptr + array->length, string, length);
+  array->value = ptr;
+  array->length = new_length;
+  return 0;
+}
+
+/**
+ * Put a string to in front of an existing string array. Only use this
+ * if the string-array value has been allocated with malloc/calloc.
+ * @param array pointer to string array object
+ * @param string pointer to string to append
+ * @return 0 if string was appended, -1 if an error happened
+ */
+int
+strarray_prepend(struct strarray *array, const char *string) {
+  size_t length, new_length;
+  char *ptr;
+
+  length = strlen(string) + 1;
+
+  new_length = array->length + length;
+  ptr = realloc(array->value, STRARRAY_MEMSIZE(new_length));
+  if (ptr == NULL) {
+    return -1;
+  }
+
+  memmove(ptr + length, ptr, array->length);
+  memcpy(ptr, string, length);
+  array->value = ptr;
+  array->length = new_length;
+  return 0;
+}
+
+/**
+ * Remove an element from a string array
+ * @param array pointer to string array object
+ * @param element an element to be removed from the array
+ * @param resize array afterwards
+ */
+void
+strarray_remove_ext(struct strarray *array, char *element, bool resize) {
+  char *ptr1;
+  size_t len;
+
+  /* get length of element to remove */
+  len = strlen(element) + 1;
+  if (len == array->length) {
+    strarray_free(array);
+    return;
+  }
+
+  /* adjust length */
+  array->length -= len;
+
+  /* remove element from memory */
+  if (element <= array->value + array->length) {
+    memmove(element, element + len, array->length - (element - array->value));
+  }
+
+  if (!resize) {
+    return;
+  }
+
+  /* adjust memory block */
+  ptr1 = realloc(array->value, STRARRAY_MEMSIZE(array->length));
+  if (ptr1 == NULL) {
+    /* just keep the current memory block */
+    return;
+  }
+
+  /* adjust value pointer to new memory block */
+  array->value = ptr1;
+}
+
+/**
+ * @param array pointer to strarray object
+ * @return number of strings in string array
+ */
+size_t
+strarray_get_count(const struct strarray *array) {
+  size_t count = 0;
+  char *ptr;
+
+  strarray_for_each_element(array, ptr) {
+    count++;
+  }
+  return count;
+}
+
+/**
+ * @param array pointer to strarray object
+ * @param idx position of the requested object inside the array
+ * @return string at the specified index, NULL if not found
+ */
+char *
+strarray_get(const struct strarray *array, size_t idx) {
+  size_t count = 0;
+  char *ptr;
+
+  strarray_for_each_element(array, ptr) {
+    if (count == idx) {
+      return ptr;
+    }
+    count++;
+  }
+  return NULL;
+}
+
+/**
+ * Compare to stringarrays
+ * @param a1 pointer to array 1
+ * @param a2 pointer to array 2
+ * @return <0 if a1 is 'smaller' than a2, >0 if a1 is 'larger' than a2,
+ *   0 if both are the same.
+ */
+int
+strarray_cmp(const struct strarray *a1, const struct strarray *a2) {
+  int result;
+  size_t min_len;
+
+  if (a1 == NULL || a1->value == NULL) {
+    return (a2 == NULL || a2->value == NULL) ? 0 : -1;
+  }
+  if (a2 == NULL || a2->value == NULL) {
+    return 1;
+  }
+
+  if (a1->length > a2->length) {
+    min_len = a2->length;
+  }
+  else {
+    min_len = a1->length;
+  }
+
+  result = memcmp(a1->value, a2->value, min_len);
+  if (result == 0) {
+    if (a1->length > a2->length) {
+      return 1;
+    }
+    if (a1->length < a2->length) {
+      return -1;
+    }
+  }
+  return result;
+}

--- a/sys/oonf_api/common/string.h
+++ b/sys/oonf_api/common/string.h
@@ -1,0 +1,356 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+
+#ifndef COMMON_STRING_H_
+#define COMMON_STRING_H_
+
+#include <ctype.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+#include "common/common_types.h"
+
+enum
+{
+  /*! block size for allocated string arrays */
+  STRARRAY_BLOCKSIZE = 64
+};
+
+/**
+ * Macro to statically initialize a string array
+ * @param str string array representation
+ */
+#define STRARRAY_INIT(str)                                                                                             \
+  { .value = (str), .length = sizeof(str) }
+
+/**
+ * Represents a string or an array of strings
+ * The strings (including the zero byte) are just appended
+ * into a large binary buffer. The struct contains a pointer
+ * to the first string and the size of the binary buffer
+ *
+ * typically append operations are done by realloc() calls
+ * while remove operations are done with memmove
+ */
+struct strarray {
+  /*! pointer to the first string */
+  char *value;
+
+  /*! total length of all strings including zero-bytes */
+  size_t length;
+};
+
+/**
+ * Constant value variant of strarray
+ */
+struct const_strarray {
+  /*! pointer to the first string */
+  const char *value;
+
+  /*! total length of all strings including zero-bytes */
+  size_t length;
+};
+
+EXPORT char *strscpy(char *dest, const char *src, size_t size);
+EXPORT char *strscat(char *dest, const char *src, size_t size);
+EXPORT char *str_trim(char *ptr);
+EXPORT const char *str_hasnextword(const char *buffer, const char *word);
+EXPORT const char *str_cpynextword(char *dst, const char *buffer, size_t len);
+EXPORT const char *str_skipnextword(const char *src);
+EXPORT size_t str_countwords(const char *src);
+
+EXPORT bool str_is_printable(const char *value);
+
+EXPORT int strarray_copy(struct strarray *dst, const struct strarray *src);
+EXPORT int strarray_append(struct strarray *, const char *);
+EXPORT int strarray_prepend(struct strarray *array, const char *string);
+EXPORT void strarray_remove_ext(struct strarray *, char *, bool);
+
+EXPORT char *strarray_get(const struct strarray *array, size_t idx);
+EXPORT size_t strarray_get_count(const struct strarray *array);
+
+EXPORT int strarray_cmp(const struct strarray *a1, const struct strarray *a2);
+
+/**
+ * @param c character
+ * @return true if character is printable, false otherwise
+ */
+static INLINE bool
+str_char_is_printable(char c) {
+  unsigned char uc = (unsigned char)c;
+  return !(uc < 32 || uc == 127 || uc == 255);
+}
+
+/**
+ * @param string string
+ * @param pattern pattern that might be in the string
+ * @return true if string starts with the pattern, false otherwise
+ */
+static INLINE bool
+str_startswith(const char *string, const char *pattern) {
+  return strncmp(string, pattern, strlen(pattern)) == 0;
+}
+
+/**
+ * This function tests if a string starts with a pattern,
+ * ignoring upper/lowercase
+ * @param string string
+ * @param pattern pattern that might be in the string
+ * @return true if string starts with the pattern, false otherwise
+ */
+static INLINE bool
+str_startswith_nocase(const char *string, const char *pattern) {
+  return strncasecmp(string, pattern, strlen(pattern)) == 0;
+}
+
+/**
+ * @param string string
+ * @param pattern pattern that might be in the string
+ * @return true if string ends with the pattern, false otherwise
+ */
+static INLINE bool
+str_endswith(const char *string, const char *pattern) {
+  size_t s_len, p_len;
+
+  s_len = strlen(string);
+  p_len = strlen(pattern);
+
+  return s_len > p_len && strcmp(&string[s_len - p_len], pattern) == 0;
+}
+
+/**
+ * This function tests if a string ends with a pattern,
+ * ignoring upper/lowercase
+ * @param string string
+ * @param pattern pattern that might be in the string
+ * @return true if string ends with the pattern, false otherwise
+ */
+static INLINE bool
+str_endswith_nocase(const char *string, const char *pattern) {
+  size_t s_len, p_len;
+
+  s_len = strlen(string);
+  p_len = strlen(pattern);
+
+  return s_len > p_len && strcasecmp(&string[s_len - p_len], pattern) == 0;
+}
+
+/**
+ * Copy a constant string array into a second array
+ * @param dst target array
+ * @param src constant source array
+ * @return 0 if array was copied, -1 if an error happened
+ */
+static INLINE int
+strarray_copy_c(struct strarray *dst, const struct const_strarray *src) {
+  return strarray_copy(dst, (const struct strarray *)src);
+}
+
+/**
+ * Get a string of an string array
+ * @param array source array
+ * @param idx index of string to be extracted
+ * @return string at the specified index, NULL if not found
+ */
+static INLINE const char *
+strarray_get_c(const struct const_strarray *array, size_t idx) {
+  return strarray_get((const struct strarray *)array, idx);
+}
+
+/**
+ * @param array constant string array
+ * @return number of strings in string array
+ */
+static INLINE size_t
+strarray_get_count_c(const struct const_strarray *array) {
+  return strarray_get_count((const struct strarray *)array);
+}
+
+/**
+ * Initialize string array object
+ * @param array pointer to string array object
+ */
+static INLINE void
+strarray_init(struct strarray *array) {
+  memset(array, 0, sizeof(*array));
+}
+
+/**
+ * Free memory of string array object
+ * @param array pointer to string array object
+ */
+static INLINE void
+strarray_free(struct strarray *array) {
+  free(array->value);
+  strarray_init(array);
+}
+
+/**
+ * @param array pointer to string array object
+ * @return true if the array is empty, false otherwise
+ */
+static INLINE bool
+strarray_is_empty(const struct strarray *array) {
+  return array->value == NULL;
+}
+
+/**
+ * @param array pointer to constant string array object
+ * @return true if the array is empty, false otherwise
+ */
+static INLINE bool
+strarray_is_empty_c(const struct const_strarray *array) {
+  return array->value == NULL;
+}
+
+/**
+ * Remove an element from a string array
+ * @param array pointer to string array object
+ * @param element an element to be removed from the array
+ */
+static INLINE void
+strarray_remove(struct strarray *array, char *element) {
+  strarray_remove_ext(array, element, true);
+}
+
+/**
+ * @param array pointer to strarray object
+ * @return pointer to first string of string array
+ */
+static INLINE char *
+strarray_get_first(const struct strarray *array) {
+  return array->value;
+}
+
+/**
+ * @param array pointer to constant strarray object
+ * @return pointer to first string of string array
+ */
+static INLINE const char *
+strarray_get_first_c(const struct const_strarray *array) {
+  return array->value;
+}
+
+/**
+ * Do not call this function for the last string in
+ * a string array.
+ * @param current pointer to a string in array
+ * @return pointer to next string in string array
+ */
+static INLINE char *
+strarray_get_next(char *current) {
+  return current + strlen(current) + 1;
+}
+
+/**
+ * Do not call this function for the last string in
+ * a string array.
+ * @param current pointer to a string in constant array
+ * @return pointer to next string in string array
+ */
+static INLINE const char *
+strarray_get_next_c(const char *current) {
+  return current + strlen(current) + 1;
+}
+
+/**
+ * @param array pointer to strarray object
+ * @param current pointer to a string in array
+ * @return pointer to next string in string array,
+ *   NULL if there is no further string
+ */
+static INLINE char *
+strarray_get_next_safe(const struct strarray *array, char *current) {
+  char *next;
+
+  next = current + strlen(current) + 1;
+  if (next > array->value + array->length) {
+    return NULL;
+  }
+  return next;
+}
+
+/**
+ * @param array pointer to constant strarray object
+ * @param current pointer to a string in array
+ * @return pointer to next string in string array,
+ *   NULL if there is no further string
+ */
+static INLINE const char *
+strarray_get_next_safe_c(const struct const_strarray *array, const char *current) {
+  const char *next;
+
+  next = current + strlen(current) + 1;
+  if (next > array->value + array->length) {
+    return NULL;
+  }
+  return next;
+}
+
+/**
+ * Compare two constant stringarrays
+ * @param a1 pointer to array 1
+ * @param a2 pointer to array 2
+ * @return <0 if a1 is 'smaller' than a2, >0 if a1 is 'larger' than a2,
+ *   0 if both are the same.
+ */
+static INLINE int
+strarray_cmp_c(const struct const_strarray *a1, const struct const_strarray *a2) {
+  return strarray_cmp((const struct strarray *)a1, (const struct strarray *)a2);
+}
+
+/**
+ * Loop over an array of strings. This loop should not be used if elements are
+ * removed from the array during the loop.
+ *
+ * @param array pointer to strarray object
+ * @param charptr pointer to loop variable
+ */
+#define strarray_for_each_element(array, charptr)                                                                      \
+  for (charptr = (array)->value; charptr != NULL && (size_t)charptr < (size_t)(array)->value + (array)->length;        \
+       charptr += strlen(charptr) + 1)
+
+#endif

--- a/sys/oonf_api/rfc5444/rfc5444.c
+++ b/sys/oonf_api/rfc5444/rfc5444.c
@@ -1,0 +1,250 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+#include <assert.h>
+
+#include "common/common_types.h"
+#include "rfc5444.h"
+
+/**
+ * Retrieve a timetlv value from a vector of hopcount/value sequences.
+ * See RFC 5497, Section 5 for details.
+ * @param vector pointer to timetlv vector
+ * @param vector_length length of vector
+ * @param hopcount hopcount for value lookup
+ * @return timetlv value, 255 (infinite) if an error happened.
+ */
+uint8_t
+rfc5497_timetlv_get_from_vector(const uint8_t *vector, size_t vector_length, uint8_t hopcount) {
+  size_t i;
+
+  /* handle illegal vector length */
+  if ((vector_length & 1) == 0) {
+    /* return infinite value */
+    return 255;
+  }
+
+  for (i = 1; i < vector_length; i += 2) {
+    /* find our position in the vector */
+    if (hopcount <= vector[i]) {
+      return vector[i - 1];
+    }
+  }
+
+  /* use the last field of the vector */
+  return vector[i - 1];
+}
+
+/**
+ * Converts a relative time value into its RFC 5497 (timetlv)
+ * representation.
+ * If the time value is larger than the largest timetlv encoding,
+ * the largest encoding (255) will be returned.
+ * If the time value is zero, the function returns zero.
+ *
+ * @param decoded relative timestamp in milliseconds
+ * @return RFC 5497 encoded time
+ */
+uint8_t
+rfc5497_timetlv_encode(uint64_t decoded) {
+  uint32_t a, b;
+  /*
+   * t = (1 + a/8) * 2^b * 1000 / 1024
+   *   = (1000 + 125 * a) * (2^b / 2^10)
+   *   = (1000 + 125 * a) * 2 ^ (b-10)
+   */
+
+  if (decoded < RFC5497_TIMETLV_MIN) {
+    return 0;
+  }
+  if (decoded > RFC5497_TIMETLV_MAX) {
+    return 255;
+  }
+
+  b = 10;
+  if (decoded >= 1000) {
+    /* this means b >= 10 */
+    while (decoded > 1875) {
+      b++;
+
+      /* divide by 2 and round up */
+      decoded++;
+      decoded >>= 1;
+    }
+  }
+  else { /* decoded < 1000 */
+    /* b < 10 */
+    while (decoded < 1000) {
+      b--;
+      decoded <<= 1;
+    }
+  }
+
+  a = (decoded - 1000 + 124) / 125;
+  return a + (b << 3);
+}
+
+/**
+ * Decode an RFC 5497 encoding into a relative time value.
+ * If the encoded data is zero, the function returns 0.
+ *
+ * @param encoded RFC 5497 encoded time
+ * @return relative time in milliseconds
+ */
+uint64_t
+rfc5497_timetlv_decode(uint8_t encoded) {
+  /*
+   * time-value := (1 + a/8) * 2^b * C
+   * time-code := 8 * b + a
+   */
+  uint8_t a, b;
+
+  if (encoded == 0) {
+    /* minimum valid time interval */
+    return 0;
+  }
+
+  if (encoded == 255) {
+    /* return 'infinite' */
+    return UINT64_MAX;
+  }
+
+  a = encoded & 0x07;
+  b = encoded >> 3;
+
+  /*
+   * C is 1000/1024 for us, because we calculate in ms
+   *
+   * t = (1 + a/8) * 2^b * 1000 / 1024
+   *   = (1000 + 125 * a) * 2^b / 2^10
+   *
+   * Case 1: b <= 10
+   *   = (1000 + 125 * a) >> (10 - b)
+   *
+   * Case 2: b > 10
+   *   = (1000 + 125 * a) << (b - 10)
+   */
+
+  if (b <= 10) {
+    return (1000ull + 125ull * a) >> (10ull - b);
+  }
+  return (1000ull + 125ull * a) << (b - 10ull);
+}
+
+/**
+ * Encode a metric value in RFC7181 (OLSRv2) specified format.
+ * A metric value of zero or larger than RFC7181_METRIC_INFINITE
+ * will return an error.
+ * A metric value larger than the RFC7181_METRIC_MAX will be encoded to 4095.
+ * @param encoded pointer to encoded metric value
+ * @param decoded metric value.
+ * @return encoded -1 if an error happened, 0 otherwise.
+ */
+int
+rfc7181_metric_encode(struct rfc7181_metric_field *encoded, uint32_t decoded) {
+  uint8_t a, b;
+  /*
+   * metric-value := (257+b)2^a - 256
+   * metric-code := 256 * a + b
+   */
+
+  if (decoded < RFC7181_METRIC_MIN || decoded >= RFC7181_METRIC_INFINITE) {
+    return -1;
+  }
+  if (decoded > RFC7181_METRIC_MAX) {
+    encoded->b[0] = 0x0f;
+    encoded->b[1] = 0xff;
+    return 0;
+  }
+
+  /* metric-value + 256 = (257+b)<<a */
+  decoded += 256;
+
+  a = 0;
+  while (decoded > 512) {
+    a++;
+
+    /* divide by 2 and round up */
+    decoded++;
+    decoded >>= 1;
+  }
+
+  b = decoded - 257;
+
+  encoded->b[0] = a;
+  encoded->b[1] = b;
+
+  return 0;
+}
+
+/**
+ * Decode a RFC7181 (OLSRv2) encoded metric value.
+ * @param encoded encoded metric
+ * @return decoded metric value
+ */
+uint32_t
+rfc7181_metric_decode(struct rfc7181_metric_field *encoded) {
+  uint8_t exponent = encoded->b[0] & 15;
+  return ((257 + encoded->b[1]) << exponent) - 256;
+}
+
+/**
+ * Calculate the difference between two sequence numbers
+ * @param seqno1 first sequence number
+ * @param seqno2 second sequence number
+ * @return difference between both
+ */
+int
+rfc5444_seqno_difference(uint16_t seqno1, uint16_t seqno2) {
+  int diff = (int)seqno1 - (int)(seqno2);
+
+  // overflow ?
+  if (diff > (1 << 15)) {
+    diff -= (1 << 16);
+  }
+  else if (diff < -(1 << 15)) {
+    diff += (1 << 16);
+  }
+  return diff;
+}

--- a/sys/oonf_api/rfc5444/rfc5444.h
+++ b/sys/oonf_api/rfc5444/rfc5444.h
@@ -1,0 +1,148 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+#ifndef RFC5444_CONVERSION_H_
+#define RFC5444_CONVERSION_H_
+
+#include "common/common_types.h"
+#include "rfc5444_iana.h"
+
+enum
+{
+  /* timetlv_max = 14 * 2^28 * 1000 / 1024 = 14000 << 18 = 3 670 016 000 ms */
+  RFC5497_TIMETLV_MAX = 0xdac00000,
+
+  /* timetlv_min = 1000/1024 ms */
+  RFC5497_TIMETLV_MIN = 0x00000001,
+
+  /* metric_max = 1<<24 - 256 */
+  RFC7181_METRIC_MAX = 0xffff00,
+
+  /* metric_min = 1 */
+  RFC7181_METRIC_MIN = 0x000001,
+
+  /* larger than possible metric value */
+  RFC7181_METRIC_INFINITE = 0xffffff,
+
+  /* infinite path cost */
+  RFC7181_METRIC_INFINITE_PATH = 0xffffffff,
+};
+
+/**
+ * Binary Metric TLV value of RFC7181
+ */
+struct rfc7181_metric_field {
+  /*! two byte value */
+  uint8_t b[2];
+};
+
+EXPORT uint8_t rfc5497_timetlv_get_from_vector(const uint8_t *vector, size_t vector_length, uint8_t hopcount);
+EXPORT uint8_t rfc5497_timetlv_encode(uint64_t);
+EXPORT uint64_t rfc5497_timetlv_decode(uint8_t);
+
+EXPORT int rfc7181_metric_encode(struct rfc7181_metric_field *, uint32_t);
+EXPORT uint32_t rfc7181_metric_decode(struct rfc7181_metric_field *);
+
+EXPORT int rfc5444_seqno_difference(uint16_t, uint16_t);
+
+/**
+ * Compares two RFC5444 sequence numbers
+ * @param s1 first sequence number
+ * @param s2 second sequence number
+ * @return true if first is larger than second number
+ */
+static INLINE bool
+rfc5444_seqno_is_larger(uint16_t s1, uint16_t s2) {
+  /*
+   * The sequence number S1 is said to be "greater than" the sequence
+   * number S2 if:
+   * o  S1 > S2 AND S1 - S2 < MAXVALUE/2 OR
+   * o  S2 > S1 AND S2 - S1 > MAXVALUE/2
+   */
+  return (s1 > s2 && (s1 - s2) < (1 << 15)) || (s2 > s1 && (s2 - s1) > (1 << 15));
+}
+
+/**
+ * Compares two RFC5444 sequence numbers
+ * @param s1 first sequence number
+ * @param s2 second sequence number
+ * @return true if first is smaller than second number
+ */
+static INLINE bool
+rfc5444_seqno_is_smaller(uint16_t s1, uint16_t s2) {
+  return s1 != s2 && !rfc5444_seqno_is_larger(s1, s2);
+}
+
+/**
+ * Test for metric flag
+ * @param metric metric field
+ * @param flag flag to test for
+ * @return true if flag is set, false otherwise
+ */
+static INLINE bool
+rfc7181_metric_has_flag(struct rfc7181_metric_field *metric, enum rfc7181_linkmetric_flags flag) {
+  return (metric->b[0] & (uint8_t)flag) != 0;
+}
+
+/**
+ * Set a metric flag
+ * @param metric metric field
+ * @param flag flag to set
+ */
+static INLINE void
+rfc7181_metric_set_flag(struct rfc7181_metric_field *metric, enum rfc7181_linkmetric_flags flag) {
+  metric->b[0] |= (uint8_t)flag;
+}
+
+/**
+ * Reset a metric flag
+ * @param metric metric field
+ * @param flag flag to reset
+ */
+static INLINE void
+rfc7181_metric_reset_flag(struct rfc7181_metric_field *metric, enum rfc7181_linkmetric_flags flag) {
+  metric->b[0] &= ~((uint8_t)flag);
+}
+
+#endif /* RFC5444_CONVERSION_H_ */

--- a/sys/oonf_api/rfc5444/rfc5444_context.c
+++ b/sys/oonf_api/rfc5444/rfc5444_context.c
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,33 +38,43 @@
  * the copyright holders.
  *
  */
-#include <rfc5444/rfc5444_context.h>
+
+/**
+ * @file
+ */
+
+#include "rfc5444_context.h"
 
 static const char *_rfc5444_positive_result_texts[] = {
-  [RFC5444_OKAY]                 = "Okay",
-  [RFC5444_DROP_TLV]             = "Drop TLV",
+  [RFC5444_OKAY] = "Okay",
+  [RFC5444_DROP_TLV] = "Drop TLV",
   [RFC5444_DROP_MSG_BUT_FORWARD] = "Drop message but forward it",
-  [RFC5444_DROP_MESSAGE]         = "Drop message",
-  [RFC5444_DROP_PACKET]          = "Drop packet",
+  [RFC5444_DROP_MESSAGE] = "Drop message",
+  [RFC5444_DROP_PACKET] = "Drop packet",
 };
 
 static const char *_rfc5444_negative_result_texts[] = {
-  [RFC5444_OKAY]                 = "Okay",
-  [-RFC5444_UNSUPPORTED_VERSION]  = "Version of rfc5444 not supported",
-  [-RFC5444_END_OF_BUFFER]        = "Early end of packet",
-  [-RFC5444_BAD_TLV_IDXFLAGS]     = "Bad combination of index flags",
-  [-RFC5444_BAD_TLV_VALUEFLAGS]   = "Bad combination of value flags",
-  [-RFC5444_BAD_TLV_LENGTH]       = "TLV length is no multiple of number of values",
-  [-RFC5444_OUT_OF_MEMORY]        = "Memory allocation failed",
-  [-RFC5444_EMPTY_ADDRBLOCK]      = "Address block with zero addresses",
-  [-RFC5444_BAD_MSG_TAILFLAGS]    = "Bad combination of address tail flags",
-  [-RFC5444_BAD_MSG_PREFIXFLAGS]  = "Bad combination of address prefix length flags",
-  [-RFC5444_DUPLICATE_TLV]        = "Duplicate address TLV",
-  [-RFC5444_OUT_OF_ADDRTLV_MEM]   = "Not enough memory for address-TLVs",
-  [-RFC5444_MTU_TOO_SMALL]        = "Configured MTU size too small",
-  [-RFC5444_NO_MSGCREATOR]        = "Cannot create message without message creator",
-  [-RFC5444_FW_MESSAGE_TOO_LONG]  = "Cannot forward message, content too long",
-  [-RFC5444_FW_BAD_SIZE]          = "Bad length field of message to be forwarded",
+  [RFC5444_OKAY] = "Okay",
+  [-RFC5444_UNSUPPORTED_VERSION] = "Version of rfc5444 not supported",
+  [-RFC5444_END_OF_BUFFER] = "Early end of packet",
+  [-RFC5444_BAD_TLV_IDXFLAGS] = "Bad combination of tlv index flags",
+  [-RFC5444_BAD_TLV_VALUEFLAGS] = "Bad combination of tlv value flags",
+  [-RFC5444_BAD_TLV_LENGTH] = "TLV length is no multiple of number of values",
+  [-RFC5444_OUT_OF_MEMORY] = "Memory allocation failed",
+  [-RFC5444_EMPTY_ADDRBLOCK] = "Address block with zero addresses",
+  [-RFC5444_BAD_MSG_TAILFLAGS] = "Bad combination of address tail flags",
+  [-RFC5444_BAD_MSG_PREFIXFLAGS] = "Bad combination of address prefix length flags",
+  [-RFC5444_DUPLICATE_TLV] = "Duplicate address TLV",
+  [-RFC5444_OUT_OF_ADDRTLV_MEM] = "Not enough memory for address-TLVs",
+  [-RFC5444_MTU_TOO_SMALL] = "Configured MTU size too small",
+  [-RFC5444_NO_MSGCREATOR] = "Cannot create message without message creator",
+  [-RFC5444_FW_MESSAGE_TOO_LONG] = "Cannot forward message, content too long",
+  [-RFC5444_FW_BAD_SIZE] = "Bad length field of message to be forwarded",
+  [-RFC5444_TOO_LARGE] = "RFC5444 packet larger than 64k",
+  [-RFC5444_FW_BAD_TRANSFORM] = "RFC5444 transformer failed",
+  [-RFC5444_BAD_ADDR_HEAD_LENGTH] = "Bad addrblock head length",
+  [-RFC5444_BAD_ADDR_TAIL_LENGTH] = "Bad addrblock tail length",
+  [-RFC5444_BAD_TLV_INDEX] = "Bad tlv index fields",
 };
 
 /**

--- a/sys/oonf_api/rfc5444/rfc5444_context.h
+++ b/sys/oonf_api/rfc5444/rfc5444_context.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,118 +38,147 @@
  * the copyright holders.
  *
  */
+
+/**
+ * @file
+ */
 #ifndef RFC5444_CONTEXT_H_
 #define RFC5444_CONTEXT_H_
 
-#include "rfc5444/rfc5444_api_config.h"
+#include "common/common_types.h"
+#include "rfc5444_api_config.h"
 
-/*
+/**
  * Return values for reader callbacks and API calls (and internal functions)
  * The RFC5444_DROP_... constants are ordered, higher values mean
  * dropping more of the context.
  * All return values less than zero represent an error.
- *
- * RFC5444_DROP_TLV means to drop the current tlv
- * RFC5444_DROP_ADDRESS means to drop the current address
- * RFC5444_DROP_MESSAGE means to drop the current message
- * RFC5444_DROP_MESSAGE_BUT_FORWARD means to drop the current message
- *   but forward allow to forward it
- * RFC5444_DROP_PACKET means to drop the whole packet
- *
- * RFC5444_OKAY means everything is okay
- *
- * RFC5444_UNSUPPORTED_VERSION
- *   version field of rfc5444 is not 0
- * RFC5444_END_OF_BUFFER
- *   end of rfc5444 data stream before end of message/tlv
- * RFC5444_BAD_TLV_IDXFLAGS
- *   illegal combination of thassingleindex and thasmultiindex flags
- * RFC5444_BAD_TLV_VALUEFLAGS
- *   illegal combination of thasvalue and thasextlen flag
- * RFC5444_BAD_TLV_LENGTH
- *   length of tlv is no multiple of number of values
- * RFC5444_OUT_OF_MEMORY
- *   dynamic memory allocation failed
- * RFC5444_EMPTY_ADDRBLOCK
- *   address block with 0 addresses found
- * RFC5444_BAD_MSG_TAILFLAGS
- *   illegal combination of ahasfulltail and ahaszerotail flag
- * RFC5444_BAD_MSG_PREFIXFLAGS
- *   illegal combination of ahassingleprelen and ahasmultiprelen flag
- * RFC5444_DUPLICATE_TLV
- *   address tlv already exists
- * RFC5444_OUT_OF_ADDRTLV_MEM
- *   internal buffer for address tlv values too small
- * RFC5444_MTU_TOO_SMALL
- *   non-fragmentable part of message does not fit into max sizes packet
- * RFC5444_NO_MSGCREATOR
- *   cannot create a message without a message creator
- * RFC5444_FW_MESSAGE_TOO_LONG
- *   bad format of forwarded message, does not fit into max sized packet
- * RFC5444_FW_BAD_SIZE
- *   bad format of forwarded message, size field wrong
  */
-enum rfc5444_result {
+enum rfc5444_result
+{
 #if DISALLOW_CONSUMER_CONTEXT_DROP == false
-  RFC5444_RESULT_MAX           =  5,
-  RFC5444_DROP_PACKET          =  5,
-  RFC5444_DROP_MESSAGE         =  4,
-  RFC5444_DROP_MSG_BUT_FORWARD =  3,
-  RFC5444_DROP_ADDRESS         =  2,
-  RFC5444_DROP_TLV             =  1,
+  /*! maximum value of result */
+  RFC5444_RESULT_MAX = 5,
+
+  /*! drop whole packet */
+  RFC5444_DROP_PACKET = 5,
+
+  /*! drop message */
+  RFC5444_DROP_MESSAGE = 4,
+
+  /*! drop message but still forward it if possible */
+  RFC5444_DROP_MSG_BUT_FORWARD = 3,
+
+  /*! drop address and attached TLVs */
+  RFC5444_DROP_ADDRESS = 2,
+
+  /*! drop TLV */
+  RFC5444_DROP_TLV = 1,
 #endif
-  RFC5444_OKAY                 =  0,
-  RFC5444_UNSUPPORTED_VERSION  = -1,
-  RFC5444_END_OF_BUFFER        = -2,
-  RFC5444_BAD_TLV_IDXFLAGS     = -3,
-  RFC5444_BAD_TLV_VALUEFLAGS   = -4,
-  RFC5444_BAD_TLV_LENGTH       = -5,
-  RFC5444_OUT_OF_MEMORY        = -6,
-  RFC5444_EMPTY_ADDRBLOCK      = -7,
-  RFC5444_BAD_MSG_TAILFLAGS    = -8,
-  RFC5444_BAD_MSG_PREFIXFLAGS  = -9,
-  RFC5444_DUPLICATE_TLV        = -10,
-  RFC5444_OUT_OF_ADDRTLV_MEM   = -11,
-  RFC5444_MTU_TOO_SMALL        = -12,
-  RFC5444_NO_MSGCREATOR        = -13,
-  RFC5444_FW_MESSAGE_TOO_LONG  = -14,
-  RFC5444_FW_BAD_SIZE          = -15,
-  RFC5444_RESULT_MIN           = -15,
+  /*! everything worked fine */
+  RFC5444_OKAY = 0,
+
+  /*! version field of rfc5444 is not 0 */
+  RFC5444_UNSUPPORTED_VERSION = -1,
+
+  /*! end of rfc5444 data stream before end of message/tlv */
+  RFC5444_END_OF_BUFFER = -2,
+
+  /*! illegal combination of thassingleindex and thasmultiindex flags */
+  RFC5444_BAD_TLV_IDXFLAGS = -3,
+
+  /*! illegal combination of thasvalue and thasextlen flag */
+  RFC5444_BAD_TLV_VALUEFLAGS = -4,
+
+  /*! length of tlv is no multiple of number of values */
+  RFC5444_BAD_TLV_LENGTH = -5,
+
+  /*! dynamic memory allocation failed */
+  RFC5444_OUT_OF_MEMORY = -6,
+
+  /*! address block with 0 addresses found */
+  RFC5444_EMPTY_ADDRBLOCK = -7,
+
+  /*! illegal combination of ahasfulltail and ahaszerotail flag */
+  RFC5444_BAD_MSG_TAILFLAGS = -8,
+
+  /*! illegal combination of ahassingleprelen and ahasmultiprelen flag */
+  RFC5444_BAD_MSG_PREFIXFLAGS = -9,
+
+  /*! address tlv already exists */
+  RFC5444_DUPLICATE_TLV = -10,
+
+  /*! internal buffer for address tlv values too small */
+  RFC5444_OUT_OF_ADDRTLV_MEM = -11,
+
+  /*! non-fragmentable part of message does not fit into max sizes packet */
+  RFC5444_MTU_TOO_SMALL = -12,
+
+  /*! cannot create a message without a message creator */
+  RFC5444_NO_MSGCREATOR = -13,
+
+  /*! bad format of forwarded message, does not fit into max sized packet */
+  RFC5444_FW_MESSAGE_TOO_LONG = -14,
+
+  /*! bad format of forwarded message, size field wrong */
+  RFC5444_FW_BAD_SIZE = -15,
+
+  /*! buffer for reader is larger than 64k */
+  RFC5444_TOO_LARGE = -16,
+
+  /*! transformer failed for forwarded message */
+  RFC5444_FW_BAD_TRANSFORM = -17,
+
+  /*! head length is not between 1 and 15 */
+  RFC5444_BAD_ADDR_HEAD_LENGTH = -18,
+
+  /*! tail length is not between 1 and 15 */
+  RFC5444_BAD_ADDR_TAIL_LENGTH = -19,
+
+  /*! either start or end index is beyond the number of addresses (minus 1) */
+  RFC5444_BAD_TLV_INDEX = -20,
+
+  /*! minimal value of result */
+  RFC5444_RESULT_MIN = -20,
 };
 
-const char *rfc5444_strerror(enum rfc5444_result result);
+EXPORT const char *rfc5444_strerror(enum rfc5444_result result);
 
 /* maximum address length */
-enum { RFC5444_MAX_ADDRLEN = 16 };
+enum
+{
+  RFC5444_MAX_ADDRLEN = 16
+};
 
 /* packet flags */
-enum {
-  RFC5444_PKT_FLAGMASK         = 0x0f,
-  RFC5444_PKT_FLAG_SEQNO       = 0x08,
-  RFC5444_PKT_FLAG_TLV         = 0x04,
+enum
+{
+  RFC5444_PKT_FLAGMASK = 0x0f,
+  RFC5444_PKT_FLAG_SEQNO = 0x08,
+  RFC5444_PKT_FLAG_TLV = 0x04,
 
-/* message flags */
-  RFC5444_MSG_FLAG_ORIGINATOR  = 0x80,
-  RFC5444_MSG_FLAG_HOPLIMIT    = 0x40,
-  RFC5444_MSG_FLAG_HOPCOUNT    = 0x20,
-  RFC5444_MSG_FLAG_SEQNO       = 0x10,
+  /* message flags */
+  RFC5444_MSG_FLAG_ORIGINATOR = 0x80,
+  RFC5444_MSG_FLAG_HOPLIMIT = 0x40,
+  RFC5444_MSG_FLAG_HOPCOUNT = 0x20,
+  RFC5444_MSG_FLAG_SEQNO = 0x10,
 
   RFC5444_MSG_FLAG_ADDRLENMASK = 0x0f,
 
-/* addressblock flags */
-  RFC5444_ADDR_FLAG_HEAD       = 0x80,
-  RFC5444_ADDR_FLAG_FULLTAIL   = 0x40,
-  RFC5444_ADDR_FLAG_ZEROTAIL   = 0x20,
+  /* addressblock flags */
+  RFC5444_ADDR_FLAG_HEAD = 0x80,
+  RFC5444_ADDR_FLAG_FULLTAIL = 0x40,
+  RFC5444_ADDR_FLAG_ZEROTAIL = 0x20,
   RFC5444_ADDR_FLAG_SINGLEPLEN = 0x10,
-  RFC5444_ADDR_FLAG_MULTIPLEN  = 0x08,
+  RFC5444_ADDR_FLAG_MULTIPLEN = 0x08,
 
-/* tlv flags */
-  RFC5444_TLV_FLAG_TYPEEXT     = 0x80,
-  RFC5444_TLV_FLAG_SINGLE_IDX  = 0x40,
-  RFC5444_TLV_FLAG_MULTI_IDX   = 0x20,
-  RFC5444_TLV_FLAG_VALUE       = 0x10,
-  RFC5444_TLV_FLAG_EXTVALUE    = 0x08,
-  RFC5444_TLV_FLAG_MULTIVALUE  = 0x04,
+  /* tlv flags */
+  RFC5444_TLV_FLAG_TYPEEXT = 0x80,
+  RFC5444_TLV_FLAG_SINGLE_IDX = 0x40,
+  RFC5444_TLV_FLAG_MULTI_IDX = 0x20,
+  RFC5444_TLV_FLAG_VALUE = 0x10,
+  RFC5444_TLV_FLAG_EXTVALUE = 0x08,
+  RFC5444_TLV_FLAG_MULTIVALUE = 0x04,
 };
 
 #endif /* RFC5444_CONTEXT_H_ */

--- a/sys/oonf_api/rfc5444/rfc5444_iana.c
+++ b/sys/oonf_api/rfc5444/rfc5444_iana.c
@@ -1,0 +1,143 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+#include "common/common_types.h"
+#include "common/netaddr.h"
+
+#include "rfc5444_iana.h"
+
+static const char *_rfc7182_hashes[RFC7182_ICV_HASH_COUNT] = {
+  [RFC7182_ICV_HASH_IDENTITY] = "identity",
+  [RFC7182_ICV_HASH_SHA_1] = "sha1",
+  [RFC7182_ICV_HASH_SHA_224] = "sha224",
+  [RFC7182_ICV_HASH_SHA_256] = "sha256",
+  [RFC7182_ICV_HASH_SHA_384] = "sha384",
+  [RFC7182_ICV_HASH_SHA_512] = "sha512",
+};
+
+static const char *_rfc7182_crypt[RFC7182_ICV_CRYPT_COUNT] = {
+  [RFC7182_ICV_CRYPT_IDENTITY] = "identity",
+  [RFC7182_ICV_CRYPT_RSA] = "rsa",
+  [RFC7182_ICV_CRYPT_DSA] = "dsa",
+  [RFC7182_ICV_CRYPT_HMAC] = "hmac",
+  [RFC7182_ICV_CRYPT_3DES] = "3des",
+  [RFC7182_ICV_CRYPT_AES] = "aes",
+  [RFC7182_ICV_CRYPT_ECDSA] = "ecdsa",
+};
+
+/**
+ * Give name of rfc 7182 hash
+ * @param hash hash-id
+ * @return name of hash
+ */
+const char *
+rfc7182_get_hash_name(enum rfc7182_icv_hash hash) {
+  if (hash < 0 || hash >= RFC7182_ICV_HASH_COUNT) {
+    return "unknown";
+  }
+  return _rfc7182_hashes[hash];
+}
+
+/**
+ * Give name of rfc 7182 crypto
+ * @param crypt crypto-id
+ * @return name of crypto
+ */
+const char *
+rfc7182_get_crypt_name(enum rfc7182_icv_crypt crypt) {
+  if (crypt < 0 || crypt >= RFC7182_ICV_CRYPT_COUNT) {
+    return "unknown";
+  }
+  return _rfc7182_crypt[crypt];
+}
+
+/**
+ * @return array of rfc7182 hash names
+ */
+const char **
+rfc7182_get_hashes(void) {
+  return _rfc7182_hashes;
+}
+
+/**
+ * @return array of rfc7182 crypto names
+ */
+const char **
+rfc7182_get_crypto(void) {
+  return _rfc7182_crypt;
+}
+
+/**
+ * @param name rfc7182 hash name
+ * @return rfc7182 hash-id
+ */
+enum rfc7182_icv_hash
+rfc7182_get_hash_id(const char *name)
+{
+  size_t i;
+
+  for (i = 0; i < ARRAYSIZE(_rfc7182_hashes); i++) {
+    if (strcmp(_rfc7182_hashes[i], name) == 0) {
+      return i;
+    }
+  }
+  return RFC7182_ICV_HASH_UNKNOWN;
+}
+
+/**
+ * @param name rfc7182 crypto name
+ * @return rfc7182 crypto-id
+ */
+enum rfc7182_icv_crypt
+rfc7182_get_crypt_id(const char *name)
+{
+  size_t i;
+
+  for (i = 0; i < ARRAYSIZE(_rfc7182_crypt); i++) {
+    if (strcmp(_rfc7182_crypt[i], name) == 0) {
+      return i;
+    }
+  }
+  return RFC7182_ICV_CRYPT_UNKNOWN;
+}

--- a/sys/oonf_api/rfc5444/rfc5444_iana.h
+++ b/sys/oonf_api/rfc5444/rfc5444_iana.h
@@ -1,0 +1,417 @@
+
+/*
+ * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of olsr.org, olsrd nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ * Visit http://www.olsr.org for more information.
+ *
+ * If you find this software useful feel free to make a donation
+ * to the project. For more information see the website or contact
+ * the copyright holders.
+ *
+ */
+
+/**
+ * @file
+ */
+
+#ifndef RFC5444_IANA_H_
+#define RFC5444_IANA_H_
+
+#include "common/common_types.h"
+#include "common/netaddr.h"
+
+/**
+ * IANA network registration for RFC5444 (RFC 5498)
+ */
+enum rfc5444_iana
+{
+  /*! IP protocol for RFC5444 */
+  RFC5444_MANET_IPPROTO = 138,
+
+  /*! UDP port number for RFC5444 */
+  RFC5444_MANET_UDP_PORT = 269,
+};
+
+/*
+ * text variants of the constants above for defaults in
+ * configuration sections
+ */
+
+/*! IP protocol for RFC5444 */
+#define RFC5444_MANET_IPPROTO_TXT "138"
+
+/*! UDP port number for RFC5444 */
+#define RFC5444_MANET_UDP_PORT_TXT "269"
+
+/*! IPv4 multicast address for RFC5444 */
+#define RFC5444_MANET_MULTICAST_V4_TXT "224.0.0.109"
+
+/*! IPv6 multicast address for RFC5444 */
+#define RFC5444_MANET_MULTICAST_V6_TXT "ff02::6d"
+
+/**
+ * RFC5444 message types defined by IANA
+ */
+enum rfc5444_msgtype_iana
+{
+  /*! RFC 6130 Hello (NHDP) */
+  RFC6130_MSGTYPE_HELLO = 0,
+
+  /*! RFC 7181 Topology Control (OLSRv2) */
+  RFC7181_MSGTYPE_TC = 1,
+};
+
+/**
+ * packet TLVs defined by IANA in RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_pkttlvs_iana
+{
+  /*! integrity check value */
+  RFC7182_PKTTLV_ICV = 5,
+  RFC7182_PKTTLV_TIMESTAMP = 6,
+};
+
+/**
+ * generic message TLV defined by IANA in RFC5497 (timetlv)
+ */
+enum rfc5497_msgtlvs_iana
+{
+  RFC5497_MSGTLV_INTERVAL_TIME = 0,
+  RFC5497_MSGTLV_VALIDITY_TIME = 1,
+};
+
+/**
+ * generic message TLV defined by IANA in RFC7181 (OLSRv2)
+ */
+enum rfc7181_msgtlvs_iana
+{
+  /*! MPR willingness */
+  RFC7181_MSGTLV_MPR_WILLING = 7,
+
+  /*! continuous sequence number */
+  RFC7181_MSGTLV_CONT_SEQ_NUM = 8,
+};
+
+/**
+ * generic message TLVs defined by IANA in RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_msgtlvs_iana
+{
+  /*! integrity check value */
+  RFC7182_MSGTLV_ICV = 5,
+  RFC7182_MSGTLV_TIMESTAMP = 6,
+};
+
+/**
+ * generic message TLVs defined in RFC7722 (olsrv2-mt)
+ */
+enum rfc7722_mt_iana
+{
+  RFC7722_MSGTLV_MPR_TYPES = RFC7181_MSGTLV_MPR_WILLING,
+  RFC7722_MSGTLV_MPR_TYPES_EXT = 1,
+};
+
+/**
+ * generic message TLVs for source specific routing
+ */
+enum draft_olsrv2_ssr_iana
+{
+  DRAFT_SSR_MSGTLV_CAPABILITY = RFC7181_MSGTLV_MPR_WILLING,
+  DRAFT_SSR_MSGTLV_CAPABILITY_EXT = 2,
+};
+
+/*! default MPR_WILLINGNESS */
+#define RFC7181_WILLINGNESS_DEFAULT_STRING "7"
+
+/**
+ * Values for RFC7181 MPR willingness
+ */
+enum rfc7181_willingness_values
+{
+  RFC7181_WILLINGNESS_UNDEFINED = -1,
+  RFC7181_WILLINGNESS_MIN = 0,
+  RFC7181_WILLINGNESS_NEVER = 0,
+  RFC7181_WILLINGNESS_DEFAULT = 7,
+  RFC7181_WILLINGNESS_ALWAYS = 15,
+  RFC7181_WILLINGNESS_MAX = 15,
+
+  /*! bitmask to get willingness from octet stream */
+  RFC7181_WILLINGNESS_MASK = 0xf,
+
+  /*! bitshift between two values of willingness in octet stream */
+  RFC7181_WILLINGNESS_SHIFT = 4,
+};
+
+/**
+ * extension types of CONT_SEQ_NUM TLV of RFC7181 (OLSRv2)
+ */
+enum rfc7181_cont_seq_num_ext
+{
+  /*! TC message is complete */
+  RFC7181_CONT_SEQ_NUM_COMPLETE = 0,
+
+  /*! TC has been split up into multiple messages */
+  RFC7181_CONT_SEQ_NUM_INCOMPLETE = 1,
+
+  /*! bitmask to get continous sequence number flag */
+  RFC7181_CONT_SEQ_NUM_BITMASK = 1,
+};
+
+/**
+ * generic address TLV defined by IANA in RFC5497 (timetlv)
+ */
+enum rfc5497_addrtlv_iana
+{
+  RFC5497_ADDRTLV_INTERVAL_TIME = 0,
+  RFC5497_ADDRTLV_VALIDITY_TIME = 1,
+};
+
+/**
+ * generic address TLV defined by IANA in RFC6130 (NHDP)
+ */
+enum rfc6130_addrtlv_iana
+{
+  /*! local interface status */
+  RFC6130_ADDRTLV_LOCAL_IF = 2,
+
+  RFC6130_ADDRTLV_LINK_STATUS = 3,
+
+  /*! other neighbor status */
+  RFC6130_ADDRTLV_OTHER_NEIGHB = 4,
+};
+
+/**
+ * generic address TLVs defined by IANA in RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_addrtlv_iana
+{
+  /*! integrity check value */
+  RFC7182_ADDRTLV_ICV = 5,
+  RFC7182_ADDRTLV_TIMESTAMP = 6,
+};
+
+/**
+ * generic address TLV defined by IANA in RFC7181 (OLSRv2)
+ */
+enum rfc7181_addrtlv_iana
+{
+  RFC7181_ADDRTLV_LINK_METRIC = 7,
+
+  /*! multipoint relay */
+  RFC7181_ADDRTLV_MPR = 8,
+
+  /*! neigbor address type */
+  RFC7181_ADDRTLV_NBR_ADDR_TYPE = 9,
+  RFC7181_ADDRTLV_GATEWAY = 10,
+};
+
+/**
+ * extension types of GATEWAY TLV of RFC7181 (OLSRv2)
+ */
+enum rfc7181_gateway_ext
+{
+  /*! destination specific gateway */
+  RFC7181_DSTSPEC_GATEWAY = 0,
+
+  /*! source-destination specific gateway */
+  RFC7181_SRCSPEC_GATEWAY = 1,
+
+  /*! source-specific gateway */
+  RFC7181_SRCSPEC_DEF_GATEWAY = 2,
+};
+
+/**
+ * generic address TLV for source-specific gateway extension
+ */
+enum custom_srcspec_gateways
+{
+  /*! source prefix for source-destination specific gateway */
+  SRCSPEC_GW_ADDRTLV_SRC_PREFIX = 224,
+};
+
+/**
+ * values of LOCALIF TLV of RFC6130 (NHDP)
+ */
+enum rfc6130_localif_values
+{
+  /*! this is the interface that send the HELLO */
+  RFC6130_LOCALIF_THIS_IF = 0,
+
+  /*! this is not the interface that send the HELLO */
+  RFC6130_LOCALIF_OTHER_IF = 1,
+
+  /*! bitmask to extract localif value */
+  RFC6130_LOCALIF_BITMASK = 1,
+};
+
+/**
+ * values of LINKSTATUS TLV of RFC6130 (NHDP)
+ */
+enum rfc6130_linkstatus_values
+{
+  /*! this link neighbor was lost */
+  RFC6130_LINKSTATUS_LOST = 0,
+
+  /*! this link neighbor is symmetric */
+  RFC6130_LINKSTATUS_SYMMETRIC = 1,
+
+  /*! this link neighbor is asymmetric */
+  RFC6130_LINKSTATUS_HEARD = 2,
+
+  /*! bitmask to get LINKSTATUS flag */
+  RFC6130_LINKSTATUS_BITMASK = 3,
+};
+
+/**
+ * values of OTHERNEIGH TLV of RFC6130 (NHDP)
+ */
+enum rfc6130_otherneigh_values
+{
+  /*! this neighbor is symmetric on other interface */
+  RFC6130_OTHERNEIGHB_SYMMETRIC = 1,
+
+  /*! bitmask to get OTHERNEIGH flag */
+  RFC6130_OTHERNEIGHB_BITMASK = 1,
+};
+
+/**
+ * bit-flags for LINK_METRIC address TLV
+ */
+enum rfc7181_linkmetric_flags
+{
+  RFC7181_LINKMETRIC_INCOMING_LINK = 1 << 7,
+  RFC7181_LINKMETRIC_OUTGOING_LINK = 1 << 6,
+  RFC7181_LINKMETRIC_INCOMING_NEIGH = 1 << 5,
+  RFC7181_LINKMETRIC_OUTGOING_NEIGH = 1 << 4,
+};
+
+/**
+ * bit-flags for MPR address TLV
+ */
+enum rfc7181_mpr_bitmask
+{
+  RFC7181_MPR_FLOODING = 1 << 0,
+  RFC7181_MPR_ROUTING = 1 << 1,
+};
+
+/**
+ * bit-flags for neighbor address type TLV of RFC7181 (OLSRv2)
+ */
+enum rfc7181_nbr_addr_bitmask
+{
+  RFC7181_NBR_ADDR_TYPE_ORIGINATOR = 1,
+  RFC7181_NBR_ADDR_TYPE_ROUTABLE = 2,
+};
+
+/**
+ * type extensions for ICV tlv of RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_icv_ext
+{
+  /*! generic integrity check value */
+  RFC7182_ICV_EXT_GENERIC = 0,
+
+  /*! encrypted hash ICV */
+  RFC7182_ICV_EXT_CRYPTHASH = 1,
+
+  /*! source specific encrypted hash ICV */
+  RFC7182_ICV_EXT_SRCSPEC_CRYPTHASH = 2,
+};
+
+/**
+ * hash type registry for ICV tlv of RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_icv_hash
+{
+  RFC7182_ICV_HASH_UNKNOWN = -1,
+
+  /*! identity hash (for testing!) */
+  RFC7182_ICV_HASH_IDENTITY = 0,
+
+  RFC7182_ICV_HASH_SHA_1 = 1,
+  RFC7182_ICV_HASH_SHA_224 = 2,
+  RFC7182_ICV_HASH_SHA_256 = 3,
+  RFC7182_ICV_HASH_SHA_384 = 4,
+  RFC7182_ICV_HASH_SHA_512 = 5,
+
+  /*! number of defined hashes */
+  RFC7182_ICV_HASH_COUNT,
+};
+
+/**
+ * crypto algorithm registry for ICV tlv of RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_icv_crypt
+{
+  RFC7182_ICV_CRYPT_UNKNOWN = -1,
+
+  /*! identity hash (for testing!) */
+  RFC7182_ICV_CRYPT_IDENTITY = 0,
+  RFC7182_ICV_CRYPT_RSA = 1,
+  RFC7182_ICV_CRYPT_DSA = 2,
+  RFC7182_ICV_CRYPT_HMAC = 3,
+  RFC7182_ICV_CRYPT_3DES = 4,
+  RFC7182_ICV_CRYPT_AES = 5,
+  RFC7182_ICV_CRYPT_ECDSA = 6,
+
+  /*! number of defined crypto algorithms */
+  RFC7182_ICV_CRYPT_COUNT,
+};
+
+/**
+ * extension types for TIMESTAMP TLVs of RFC7182 (rfc5444-sec)
+ */
+enum rfc7182_timestamp_ext
+{
+  /*! strong monotonic increasing number */
+  RFC7182_TIMESTAMP_EXT_MONOTONIC = 0,
+
+  /*! unix timestamp */
+  RFC7182_TIMESTAMP_EXT_UNIX = 1,
+
+  /*! ntp timestamp */
+  RFC7182_TIMESTAMP_EXT_NTP = 2,
+
+  /*! random nounce */
+  RFC7182_TIMESTAMP_EXT_RANDOM = 3,
+};
+
+EXPORT const char *rfc7182_get_hash_name(enum rfc7182_icv_hash);
+EXPORT const char *rfc7182_get_crypt_name(enum rfc7182_icv_crypt);
+
+EXPORT const char **rfc7182_get_hashes(void);
+EXPORT const char **rfc7182_get_crypto(void);
+
+EXPORT enum rfc7182_icv_hash rfc7182_get_hash_id(const char *name);
+EXPORT enum rfc7182_icv_crypt rfc7182_get_crypt_id(const char *name);
+
+#endif /* RFC5444_IANA_H_ */

--- a/sys/oonf_api/rfc5444/rfc5444_msg_generator.c
+++ b/sys/oonf_api/rfc5444/rfc5444_msg_generator.c
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -38,36 +38,62 @@
  * the copyright holders.
  *
  */
+
+/**
+ * @file
+ */
+
+// #define DEBUG_OUTPUT
+
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef DEBUG_OUTPUT
+#include <stdio.h>
+#endif
 
-#include "rfc5444/rfc5444_writer.h"
-#include "rfc5444/rfc5444_api_config.h"
+#include "common/avl.h"
+#include "common/common_types.h"
+#include "common/list.h"
+#include "common/netaddr.h"
 
-#include "kernel_defines.h"
+#include "rfc5444_api_config.h"
+#include "rfc5444_writer.h"
 
-/* data necessary for automatic address compression */
+/**
+ * data necessary for automatic address compression
+ */
 struct _rfc5444_internal_addr_compress_session {
+  /*! address at the start of the current block */
   struct rfc5444_writer_address *ptr;
+
+  /*! total number of bytes if this compression strategy is used */
   int total;
+
+  /*! number of bytes of current address block */
   int current;
+
+  /*! true if address block has multiple prefix lengths */
   bool multiplen;
+
+  /*! true if address block has to be closed */
+  bool closed;
 };
 
-static void _calculate_tlv_flags(struct rfc5444_writer_address *addr, bool first);
-static void _close_addrblock(struct _rfc5444_internal_addr_compress_session *acs,
-    struct rfc5444_writer_message *msg, struct rfc5444_writer_address *last_addr, int);
-static void _finalize_message_fragment(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, struct rfc5444_writer_address *first,
-    struct rfc5444_writer_address *last, bool not_fragmented,
-    rfc5444_writer_targetselector useIf, void *param);
-static int _compress_address(struct _rfc5444_internal_addr_compress_session *acs,
-    struct rfc5444_writer_message *msg, struct rfc5444_writer_address *addr,
-    int same_prefixlen, bool first);
-static void _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
-    struct rfc5444_writer_address *first_addr, struct rfc5444_writer_address *last_addr);
+static void _close_addrblock(struct _rfc5444_internal_addr_compress_session *acs, struct rfc5444_writer *writer,
+  struct rfc5444_writer_address *last_addr, int);
+static void _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
+  struct oonf_list_entity *fragment_addrs, bool not_fragmented, rfc5444_writer_targetselector useIf, void *param);
+static int _compress_address(struct _rfc5444_internal_addr_compress_session *acs, struct rfc5444_writer *writer,
+  struct oonf_list_entity *addr_list, int same_prefixlen);
+static void _write_addresses(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, struct oonf_list_entity *fragment_addrs);
 static void _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg);
+static uint8_t *_write_addresstlvs(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
+  struct rfc5444_writer_address *first, struct rfc5444_writer_address *last, uint8_t *ptr);
+
+/*! temporary buffer for messages when going through a postprocessor */
+static uint8_t _msg_buffer[RFC5444_MAX_MESSAGE_SIZE];
 
 /**
  * Create a message with a defined type
@@ -75,24 +101,31 @@ static void _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_write
  *
  * @param writer pointer to writer context
  * @param msgid type of message
+ * @param addr_len length of address for this message
  * @param useIf pointer to interface selector
  * @param param last parameter of interface selector
  * @return RFC5444_OKAY if message was created and added to packet buffer,
  *   RFC5444_... otherwise
  */
 enum rfc5444_result
-rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
-    rfc5444_writer_targetselector useIf, void *param) {
+rfc5444_writer_create_message(
+  struct rfc5444_writer *writer, uint8_t msgid, uint8_t addr_len, rfc5444_writer_targetselector useIf, void *param)
+{
   struct rfc5444_writer_message *msg;
   struct rfc5444_writer_content_provider *prv;
   struct oonf_list_entity *ptr1;
-  struct rfc5444_writer_address *addr = NULL, *last_processed = NULL;
-  struct rfc5444_writer_address *first_addr = NULL, *first_mandatory = NULL;
+  struct rfc5444_writer_address *addr;
+  struct rfc5444_writer_address *first_addr;
+  struct rfc5444_writer_address *first_processed, *last_processed;
   struct rfc5444_writer_tlvtype *tlvtype;
-  struct rfc5444_writer_target *interface;
+  struct rfc5444_writer_target *target;
+  struct oonf_list_entity current_list;
+
+  struct rfc5444_writer_postprocessor *processor;
+  size_t processor_preallocation;
 
   struct _rfc5444_internal_addr_compress_session acs[RFC5444_MAX_ADDRLEN];
-  int best_size, best_head, same_prefixlen = 0;
+  int best_size, best_head, same_prefixlen;
   int i, idx, non_mandatory;
   bool first;
   bool not_fragmented;
@@ -101,7 +134,7 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
   assert(writer->_state == RFC5444_WRITER_NONE);
 #endif
 
-  /* do nothing if no interface is defined */
+  /* do nothing if no target is defined */
   if (oonf_list_is_empty(&writer->_targets)) {
     return RFC5444_OKAY;
   }
@@ -114,29 +147,29 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
   }
 
   /*
-   * test if we need interface specific messages
+   * test if we need target specific messages
    * and this is not the single_if selector
    */
   if (!msg->target_specific) {
-    /* not interface specific */
+    /* not target specific */
     writer->msg_target = NULL;
   }
   else if (useIf == rfc5444_writer_singletarget_selector) {
-    /* interface specific, but single_if selector is used */
+    /* target specific, but single_if selector is used */
     writer->msg_target = param;
   }
   else {
-    /* interface specific, but generic selector is used */
+    /* target specific, but generic selector is used */
     enum rfc5444_result result;
 
-    oonf_list_for_each_element(&writer->_targets, interface, _target_node) {
-      /* check if we should send over this interface */
-      if (!useIf(writer, interface, param)) {
+    oonf_list_for_each_element(&writer->_targets, target, _target_node) {
+      /* check if we should send over this target */
+      if (!useIf(writer, target, param)) {
         continue;
       }
 
       /* create an unique message by recursive call */
-      result = rfc5444_writer_create_message(writer, msgid, rfc5444_writer_singletarget_selector, interface);
+      result = rfc5444_writer_create_message(writer, msgid, addr_len, rfc5444_writer_singletarget_selector, target);
       if (result != RFC5444_OKAY) {
         return result;
       }
@@ -144,26 +177,37 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
     return RFC5444_OKAY;
   }
 
+  /* set address length */
+  writer->msg_addr_len = addr_len;
+
   /*
    * initialize packet buffers for all interfaces if necessary
    * and calculate message MTU
    */
+
+  /* loop over post-processors */
+  processor_preallocation = 0;
+  avl_for_each_element(&writer->_processors, processor, _node) {
+    if (processor->is_matching_signature(processor, msg->type)) {
+      processor_preallocation += processor->allocate_space;
+    }
+  }
   max_msg_size = writer->msg_size;
-  oonf_list_for_each_element(&writer->_targets, interface, _target_node) {
+  oonf_list_for_each_element(&writer->_targets, target, _target_node) {
     size_t interface_msg_mtu;
 
-    /* check if we should send over this interface */
-    if (!useIf(writer, interface, param)) {
+    /* check if we should send over this target */
+    if (!useIf(writer, target, param)) {
       continue;
     }
 
     /* start packet if necessary */
-    if (interface->_is_flushed) {
-      _rfc5444_writer_begin_packet(writer, interface);
+    if (target->_is_flushed) {
+      _rfc5444_writer_begin_packet(writer, target);
     }
 
-    interface_msg_mtu = interface->packet_size
-        - (interface->_pkt.header + interface->_pkt.added + interface->_pkt.allocated);
+    interface_msg_mtu = target->packet_size - processor_preallocation -
+                        (target->_pkt.header + target->_pkt.added + target->_pkt.allocated);
     if (interface_msg_mtu < max_msg_size) {
       max_msg_size = interface_msg_mtu;
     }
@@ -178,7 +222,14 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
   /* let the message creator write the message header */
   rfc5444_writer_set_msg_header(writer, msg, false, false, false, false);
   if (msg->addMessageHeader) {
-    msg->addMessageHeader(writer, msg);
+    if (msg->addMessageHeader(writer, msg)) {
+      /* message handler does not want this message */
+#if WRITER_STATE_MACHINE == true
+      writer->_state = RFC5444_WRITER_NONE;
+#endif
+      writer->msg_addr_len = 0;
+      return RFC5444_OKAY;
+    }
   }
 
 #if WRITER_STATE_MACHINE == true
@@ -202,11 +253,16 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
     }
   }
 
+  /* join mandatory and normal address list */
+  oonf_list_merge(&msg->_addr_head, &msg->_non_mandatory_addr_head);
+
+  /* initialize list of current addresses */
+  oonf_list_init_head(&current_list);
   not_fragmented = true;
 
   /* no addresses ? */
   if (oonf_list_is_empty(&msg->_addr_head)) {
-    _finalize_message_fragment(writer, msg, NULL, NULL, true, useIf, param);
+    _finalize_message_fragment(writer, msg, &current_list, true, useIf, param);
 #if WRITER_STATE_MACHINE == true
     writer->_state = RFC5444_WRITER_NONE;
 #endif
@@ -216,14 +272,23 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
 
   /* start address compression */
   first = true;
-  addr = first_addr = oonf_list_first_element(&msg->_addr_head, addr, _addr_node);
+  addr = first_addr = oonf_list_first_element(&msg->_addr_head, addr, _addr_oonf_list_node);
+
+  same_prefixlen = 0;
+
+  first_processed = NULL;
+  last_processed = NULL;
+
+  max_msg_size -= writer->_msg.header;
+  max_msg_size -= writer->_msg.allocated;
+  max_msg_size -= writer->_msg.added;
 
   /* loop through addresses */
   idx = 0;
   non_mandatory = 0;
   ptr1 = msg->_addr_head.next;
-  while(ptr1 != &msg->_addr_head) {
-    addr = container_of(ptr1, struct rfc5444_writer_address, _addr_node);
+  while (ptr1 != &msg->_addr_head) {
+    addr = container_of(ptr1, struct rfc5444_writer_address, _addr_oonf_list_node);
     if (addr->_done && !addr->_mandatory_addr) {
       ptr1 = ptr1->next;
       continue;
@@ -245,31 +310,21 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
       /* clear address compression session */
       memset(acs, 0, sizeof(acs));
       same_prefixlen = 1;
-    }
 
-    /* remember first mandatory address */
-    if (first_addr == NULL && addr->_mandatory_addr) {
-      first_addr = addr;
+      first_processed = addr;
     }
 
     addr->index = idx++;
-
-    /* calculate same_length/value for tlvs */
-    _calculate_tlv_flags(addr, first);
+    oonf_list_add_tail(&current_list, &addr->_addr_fragment_node);
 
     /* update session with address */
-    same_prefixlen = _compress_address(acs, msg, addr, same_prefixlen, first);
+    same_prefixlen = _compress_address(acs, writer, &current_list, same_prefixlen);
     first = false;
 
     /* look for best current compression */
     best_head = -1;
-    best_size = writer->_msg.max + 1;
-#if DO_ADDR_COMPRESSION == true
-    for (i = 0; i < msg->addr_len; i++) {
-#else
-    i=0;
-    {
-#endif
+    best_size = max_msg_size + 1;
+    for (i = 0; i < writer->msg_addr_len; i++) {
       int size = acs[i].total + acs[i].current;
       int count = addr->index - acs[i].ptr->index;
 
@@ -288,34 +343,31 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
         writer->_state = RFC5444_WRITER_NONE;
 #endif
         _rfc5444_writer_free_addresses(writer, msg);
-        return -1;
+        return RFC5444_MTU_TOO_SMALL;
       }
       not_fragmented = false;
 
-      /* close all address blocks */
-      _close_addrblock(acs, msg, last_processed, 0);
+      /* one address too many */
+      oonf_list_remove(&addr->_addr_fragment_node);
 
+      _close_addrblock(acs, writer, last_processed, 0);
+#ifdef DEBUG_OUTPUT
+      printf("Finalize with head length: %d\n", last_processed->_block_headlen);
+#endif
       /* write message fragment */
-      _finalize_message_fragment(writer, msg, first_addr, last_processed, not_fragmented, useIf, param);
+      _finalize_message_fragment(writer, msg, &current_list, not_fragmented, useIf, param);
 
-      if (first_mandatory != NULL) {
-        first_addr = first_mandatory;
-      }
-      else {
-        first_addr = addr;
-      }
+      /* reset loop */
+      oonf_list_init_head(&current_list);
+      ptr1 = &first_processed->_addr_oonf_list_node;
       first = true;
 
       /* continue without stepping forward */
       continue;
-    } else {
+    }
+    else {
       /* add cost for this address to total costs */
-#if DO_ADDR_COMPRESSION == true
-      for (i = 0; i < msg->addr_len; i++) {
-#else
-      i=0;
-      {
-#endif
+      for (i = 0; i < writer->msg_addr_len; i++) {
         acs[i].total += acs[i].current;
 
 #if DEBUG_CLEANUP == true
@@ -323,6 +375,7 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
 #endif
       }
       last_processed = addr;
+
       if (!addr->_done) {
         addr->_done = true;
 
@@ -335,14 +388,12 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
     ptr1 = ptr1->next;
   }
 
-  /* get last address */
-  addr = oonf_list_last_element(&msg->_addr_head, addr, _addr_node);
+  if (last_processed) {
+    _close_addrblock(acs, writer, last_processed, 0);
 
-  /* close all address blocks */
-  _close_addrblock(acs, msg, addr, 0);
-
-  /* write message fragment */
-  _finalize_message_fragment(writer, msg, first_addr, addr, not_fragmented, useIf, param);
+    /* write message fragment */
+    _finalize_message_fragment(writer, msg, &current_list, not_fragmented, useIf, param);
+  }
 
   /* free storage of addresses and address-tlvs */
   _rfc5444_writer_free_addresses(writer, msg);
@@ -350,32 +401,34 @@ rfc5444_writer_create_message(struct rfc5444_writer *writer, uint8_t msgid,
 #if WRITER_STATE_MACHINE == true
   writer->_state = RFC5444_WRITER_NONE;
 #endif
+  writer->msg_addr_len = 0;
+
   return RFC5444_OKAY;
 }
 
 /**
  * Single interface selector callback for message creation
- * @param writer
- * @param interf
+ * @param writer RFC5444 writer instance
+ * @param interf RFC5444 writer target
  * @param param pointer to the specified interface
  * @return true if param equals interf, false otherwise
  */
 bool
-rfc5444_writer_singletarget_selector(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_target *interf, void *param) {
+rfc5444_writer_singletarget_selector(
+  struct rfc5444_writer *writer __attribute__((unused)), struct rfc5444_writer_target *interf, void *param) {
   return interf == param;
 }
 
 /**
  * All interface selector callback for message creation
- * @param writer
- * @param interf
- * @param param
+ * @param writer RFC5444 writer instance
+ * @param interf RFC5444 writer target
+ * @param param unused
  * @return always true
  */
-bool rfc5444_writer_alltargets_selector(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_target *interf __attribute__ ((unused)),
-    void *param __attribute__ ((unused))) {
+bool
+rfc5444_writer_alltargets_selector(struct rfc5444_writer *writer __attribute__((unused)),
+  struct rfc5444_writer_target *interf __attribute__((unused)), void *param __attribute__((unused))) {
   return true;
 }
 
@@ -389,26 +442,30 @@ bool rfc5444_writer_alltargets_selector(struct rfc5444_writer *writer __attribut
  * to be compatible with the readers forward_message callback.
  *
  * @param writer pointer to writer context
+ * @param context RFC5444 reader context of message
  * @param msg pointer to message to be forwarded
  * @param len number of bytes of message
  * @return RFC5444_OKAY if the message was put into the writer buffer,
  *   RFC5444_... if an error happened
  */
 enum rfc5444_result
-rfc5444_writer_forward_msg(struct rfc5444_writer *writer, uint8_t *msg, size_t len) {
+rfc5444_writer_forward_msg(
+  struct rfc5444_writer *writer, struct rfc5444_reader_tlvblock_context *context, const uint8_t *msg, size_t len)
+{
   struct rfc5444_writer_target *target;
   struct rfc5444_writer_message *rfc5444_msg;
-  int cnt, hopcount = -1, hoplimit = -1;
-  uint16_t size;
+  struct rfc5444_writer_forward_handler *handler;
+  int cnt, hopcount, hoplimit;
+  size_t max, transformer_overhead;
+  size_t generic_size, msg_size;
   uint8_t flags, addr_len;
   uint8_t *ptr;
-  size_t max_msg_size;
-
+  bool shall_forward;
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_NONE);
 #endif
 
-  rfc5444_msg = avl_find_element(&writer->_msgcreators, &msg[0], rfc5444_msg, _msgcreator_node);
+  rfc5444_msg = avl_find_element(&writer->_msgcreators, &context->msg_type, rfc5444_msg, _msgcreator_node);
   if (rfc5444_msg == NULL) {
     /* error, no msgcreator found */
     return RFC5444_NO_MSGCREATOR;
@@ -419,46 +476,79 @@ rfc5444_writer_forward_msg(struct rfc5444_writer *writer, uint8_t *msg, size_t l
     return RFC5444_OKAY;
   }
 
-  /* check if message is small enough to be forwarded */
-  max_msg_size = 0;
+  /* 1.) first flush all interfaces that have (too) full buffers */
+  shall_forward = false;
   oonf_list_for_each_element(&writer->_targets, target, _target_node) {
-    size_t max;
-
-    if (!rfc5444_msg->forward_target_selector(target)) {
+    if (!rfc5444_msg->forward_target_selector(target, context)) {
       continue;
+    }
+
+    shall_forward = true;
+    transformer_overhead = 0;
+    avl_for_each_element(&writer->_forwarding_processors, handler, _node) {
+      if (handler->is_matching_signature(handler, msg[0])) {
+        transformer_overhead += handler->allocate_space;
+      }
+    }
+
+    max = 0;
+    if (!target->_is_flushed) {
+      max =
+        target->_pkt.max - (target->_pkt.header + target->_pkt.added + target->_pkt.allocated + target->_bin_msgs_size);
+
+      if (len + transformer_overhead > max) {
+        /* flush the old packet */
+        rfc5444_writer_flush(writer, target, false);
+      }
     }
 
     if (target->_is_flushed) {
       /* begin a new packet */
-      _rfc5444_writer_begin_packet(writer,target);
+      _rfc5444_writer_begin_packet(writer, target);
+      max =
+        target->_pkt.max - (target->_pkt.header + target->_pkt.added + target->_pkt.allocated + target->_bin_msgs_size);
     }
 
-    max = target->_pkt.max - (target->_pkt.header + target->_pkt.added + target->_pkt.allocated);
-    if (max_msg_size == 0 || max < max_msg_size) {
-      max_msg_size = max;
+    if (len + transformer_overhead > max) {
+      /* message too long, too much data in it */
+      return RFC5444_FW_MESSAGE_TOO_LONG;
     }
   }
 
-  if (max_msg_size == 0) {
-    /* no interface selected */
+  if (!shall_forward) {
+    /* no target to forward message, everything done */
     return RFC5444_OKAY;
   }
 
-  if (len > max_msg_size) {
-    /* message too long, too much data in it */
-    return RFC5444_FW_MESSAGE_TOO_LONG;
+  /* 2.) generate message and do non-target specific post processors */
+  ptr = _msg_buffer;
+  memcpy(ptr, writer->_msg.buffer, len);
+
+  /* remember length */
+  generic_size = len;
+
+  /* run processors (unpspecific) forwarding processors */
+  avl_for_each_element(&writer->_forwarding_processors, handler, _node) {
+    if (handler->is_matching_signature(handler, msg[0]) && !handler->target_specific) {
+      if (handler->process(handler, target, context, _msg_buffer, &generic_size)) {
+        /* error, we have not modified the _bin_msgs_size, so we can just return */
+        return RFC5444_FW_BAD_TRANSFORM;
+      }
+
+      if (generic_size == 0) {
+        return RFC5444_OKAY;
+      }
+    }
   }
 
+  /* 3) grab index of header structures */
   flags = msg[1];
   addr_len = (flags & RFC5444_MSG_FLAG_ADDRLENMASK) + 1;
 
-  size = (msg[2] << 8) + msg[3];
-  if (size != len) {
-    /* bad message size */
-    return RFC5444_FW_BAD_SIZE;
-  }
-
   cnt = 4;
+  hopcount = -1;
+  hoplimit = -1;
+
   if ((flags & RFC5444_MSG_FLAG_ORIGINATOR) != 0) {
     cnt += addr_len;
   }
@@ -479,33 +569,53 @@ rfc5444_writer_forward_msg(struct rfc5444_writer *writer, uint8_t *msg, size_t l
 
   /* forward message */
   oonf_list_for_each_element(&writer->_targets, target, _target_node) {
-    if (!rfc5444_msg->forward_target_selector(target)) {
+    if (!rfc5444_msg->forward_target_selector(target, context)) {
       continue;
     }
 
-    /* check if we have to flush the message buffer */
-    if (target->_pkt.header + target->_pkt.added + target->_pkt.set + target->_bin_msgs_size + len
-        > target->_pkt.max) {
-      /* flush the old packet */
-      rfc5444_writer_flush(writer, target, false);
+    ptr =
+      &target->_pkt.buffer[target->_pkt.header + target->_pkt.added + target->_pkt.allocated + target->_bin_msgs_size];
 
-      /* begin a new one */
-      _rfc5444_writer_begin_packet(writer,target);
+    /* copy message into packet buffer */
+    assert(ptr + generic_size <= target->_pkt.buffer + target->_pkt.max);
+    memcpy(ptr, msg, generic_size);
+
+    /* remember position of first copy */
+    msg_size = generic_size;
+
+    /* run processors */
+    avl_for_each_element(&writer->_forwarding_processors, handler, _node) {
+      if (handler->is_matching_signature(handler, msg[0]) && handler->target_specific) {
+        if (handler->process(handler, target, context, ptr, &msg_size)) {
+          /* error, we have not modified the _bin_msgs_size, so we can just return */
+          return RFC5444_FW_BAD_TRANSFORM;
+        }
+        if (msg_size == 0) {
+          break;
+        }
+      }
     }
 
-    ptr = &target->_pkt.buffer[target->_pkt.header + target->_pkt.added
-                            + target->_pkt.allocated + target->_bin_msgs_size];
-    memcpy(ptr, msg, len);
-    target->_bin_msgs_size += len;
+    if (msg_size > 0) {
+      target->_bin_msgs_size += msg_size;
 
-    /* correct hoplimit if necesssary */
-    if (hoplimit != -1) {
-      ptr[hoplimit]--;
-    }
+      /* correct message */
+      ptr[2] = msg_size >> 8;
+      ptr[3] = msg_size & 0xff;
 
-    /* correct hopcount if necessary */
-    if (hopcount != -1) {
-      ptr[hopcount]++;
+      /* correct hoplimit if necesssary */
+      if (hoplimit != -1) {
+        ptr[hoplimit]--;
+      }
+
+      /* correct hopcount if necessary */
+      if (hopcount != -1) {
+        ptr[hopcount]++;
+      }
+
+      if (writer->message_generation_notifier) {
+        writer->message_generation_notifier(target);
+      }
     }
   }
   return RFC5444_OKAY;
@@ -523,8 +633,9 @@ rfc5444_writer_forward_msg(struct rfc5444_writer *writer, uint8_t *msg, size_t l
  * @return RFC5444_OKAY if tlv has been added to packet, RFC5444_... otherwise
  */
 enum rfc5444_result
-rfc5444_writer_add_messagetlv(struct rfc5444_writer *writer,
-    uint8_t type, uint8_t exttype, const void *value, size_t length) {
+rfc5444_writer_add_messagetlv(
+  struct rfc5444_writer *writer, uint8_t type, uint8_t exttype, const void *value, size_t length)
+{
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_MSGTLV);
 #endif
@@ -541,8 +652,8 @@ rfc5444_writer_add_messagetlv(struct rfc5444_writer *writer,
  * @return RFC5444_OKAY if memory for tlv has been allocated, RFC5444_... otherwise
  */
 enum rfc5444_result
-rfc5444_writer_allocate_messagetlv(struct rfc5444_writer *writer,
-    bool has_exttype, size_t length) {
+rfc5444_writer_allocate_messagetlv(struct rfc5444_writer *writer, bool has_exttype, size_t length)
+{
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_MSGTLV);
 #endif
@@ -561,39 +672,13 @@ rfc5444_writer_allocate_messagetlv(struct rfc5444_writer *writer,
  * @return RFC5444_OKAY if tlv has been set to packet, RFC5444_... otherwise
  */
 enum rfc5444_result
-rfc5444_writer_set_messagetlv(struct rfc5444_writer *writer,
-    uint8_t type, uint8_t exttype, const void *value, size_t length) {
+rfc5444_writer_set_messagetlv(
+  struct rfc5444_writer *writer, uint8_t type, uint8_t exttype, const void *value, size_t length)
+{
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_FINISH_MSGTLV);
 #endif
   return _rfc5444_tlv_writer_set(&writer->_msg, type, exttype, value, length);
-}
-
-/**
- * Sets a new address length for a message
- * This function must not be called outside the message add_header callback.
- * @param writer pointer to writer context
- * @param msg pointer to message object
- * @param addrlen address length, must be less or equal than 16
- */
-void
-rfc5444_writer_set_msg_addrlen(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_message *msg, uint8_t addrlen) {
-#if WRITER_STATE_MACHINE == true
-  assert(writer->_state == RFC5444_WRITER_ADD_HEADER);
-#endif
-
-  assert(addrlen <= RFC5444_MAX_ADDRLEN);
-  assert(addrlen >= 1);
-
-  if (msg->has_origaddr && msg->addr_len != addrlen) {
-    /*
-     * we have to fix the calculated header length when set_msg_header
-     * was called before this function
-     */
-    writer->_msg.header = writer->_msg.header + addrlen - msg->addr_len;
-  }
-  msg->addr_len = addrlen;
 }
 
 /**
@@ -608,9 +693,8 @@ rfc5444_writer_set_msg_addrlen(struct rfc5444_writer *writer __attribute__ ((unu
  * @param has_seqno true if header contains a sequence number
  */
 void
-rfc5444_writer_set_msg_header(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
-    bool has_originator, bool has_hopcount, bool has_hoplimit, bool has_seqno) {
-
+rfc5444_writer_set_msg_header(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, bool has_originator,
+  bool has_hopcount, bool has_hoplimit, bool has_seqno) {
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_HEADER);
 #endif
@@ -624,7 +708,7 @@ rfc5444_writer_set_msg_header(struct rfc5444_writer *writer, struct rfc5444_writ
   writer->_msg.header = 6;
 
   if (has_originator) {
-    writer->_msg.header += msg->addr_len;
+    writer->_msg.header += writer->msg_addr_len;
   }
   if (has_hoplimit) {
     writer->_msg.header++;
@@ -647,13 +731,13 @@ rfc5444_writer_set_msg_header(struct rfc5444_writer *writer, struct rfc5444_writ
  * @param originator pointer to originator address buffer
  */
 void
-rfc5444_writer_set_msg_originator(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_message *msg, const void *originator) {
+rfc5444_writer_set_msg_originator(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, const void *originator) {
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_HEADER || writer->_state == RFC5444_WRITER_FINISH_HEADER);
 #endif
 
-  memcpy(&msg->orig_addr[0], originator, msg->addr_len);
+  memcpy(&msg->orig_addr[0], originator, writer->msg_addr_len);
 }
 
 /**
@@ -663,11 +747,11 @@ rfc5444_writer_set_msg_originator(struct rfc5444_writer *writer __attribute__ ((
  *
  * @param writer pointer to writer context
  * @param msg pointer to message object
- * @param hopcount
+ * @param hopcount hopcount to set
  */
 void
-rfc5444_writer_set_msg_hopcount(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_message *msg, uint8_t hopcount) {
+rfc5444_writer_set_msg_hopcount(
+  struct rfc5444_writer *writer __attribute__((unused)), struct rfc5444_writer_message *msg, uint8_t hopcount) {
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_HEADER || writer->_state == RFC5444_WRITER_FINISH_HEADER);
 #endif
@@ -681,11 +765,11 @@ rfc5444_writer_set_msg_hopcount(struct rfc5444_writer *writer __attribute__ ((un
  *
  * @param writer pointer to writer context
  * @param msg pointer to message object
- * @param hoplimit
+ * @param hoplimit hoplimit to set
  */
 void
-rfc5444_writer_set_msg_hoplimit(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_message *msg, uint8_t hoplimit) {
+rfc5444_writer_set_msg_hoplimit(
+  struct rfc5444_writer *writer __attribute__((unused)), struct rfc5444_writer_message *msg, uint8_t hoplimit) {
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_HEADER || writer->_state == RFC5444_WRITER_FINISH_HEADER);
 #endif
@@ -702,8 +786,8 @@ rfc5444_writer_set_msg_hoplimit(struct rfc5444_writer *writer __attribute__ ((un
  * @param seqno sequence number of message header
  */
 void
-rfc5444_writer_set_msg_seqno(struct rfc5444_writer *writer __attribute__ ((unused)),
-    struct rfc5444_writer_message *msg, uint16_t seqno) {
+rfc5444_writer_set_msg_seqno(
+  struct rfc5444_writer *writer __attribute__((unused)), struct rfc5444_writer_message *msg, uint16_t seqno) {
 #if WRITER_STATE_MACHINE == true
   assert(writer->_state == RFC5444_WRITER_ADD_HEADER || writer->_state == RFC5444_WRITER_FINISH_HEADER);
 #endif
@@ -715,170 +799,159 @@ rfc5444_writer_set_msg_seqno(struct rfc5444_writer *writer __attribute__ ((unuse
  * is finished.
  *
  * @param acs pointer to address compression session
- * @param msg pointer to message object
+ * @param writer pointer to rfc5444 writer
  * @param last_addr pointer to last address object
  * @param common_head length of common head
- * @return common_head (might be modified common_head was 1)
  */
 static void
-_close_addrblock(struct _rfc5444_internal_addr_compress_session *acs,
-    struct rfc5444_writer_message *msg __attribute__ ((unused)),
-    struct rfc5444_writer_address *last_addr, int common_head) {
+_close_addrblock(struct _rfc5444_internal_addr_compress_session *acs, struct rfc5444_writer *writer,
+  struct rfc5444_writer_address *last_addr, int common_head) {
   int best;
-#if DO_ADDR_COMPRESSION == true
   int i, size;
-  if (common_head > msg->addr_len) {
+  if (common_head > writer->msg_addr_len) {
     /* nothing to do */
     return;
   }
-#else
-  assert(common_head == 0);
-#endif
+
   /* check for best compression at closed blocks */
   best = common_head;
-#if DO_ADDR_COMPRESSION == true
   size = acs[common_head].total;
-  for (i = common_head + 1; i < msg->addr_len; i++) {
+  for (i = common_head + 1; i < writer->msg_addr_len; i++) {
     if (acs[i].total < size) {
       size = acs[i].total;
       best = i;
     }
   }
-#endif
-  /* store address block for later binary generation */
-  acs[best].ptr->_block_end = last_addr;
-  acs[best].ptr->_block_multiple_prefixlen = acs[best].multiplen;
-  acs[best].ptr->_block_headlen = best;
 
-#if DO_ADDR_COMPRESSION == true
-  for (i = common_head + 1; i < msg->addr_len; i++) {
+  if (!acs[best].closed || !last_addr->_block_start) {
+    /* store address block for later binary generation */
+    last_addr->_block_start = acs[best].ptr;
+    last_addr->_block_multiple_prefixlen = acs[best].multiplen;
+    last_addr->_block_headlen = best;
+  }
+
+  for (i = common_head + 1; i < writer->msg_addr_len; i++) {
     /* remember best block compression */
     acs[i].total = size;
   }
-#endif
   return;
-}
-
-/**
- * calculate the tlv_flags for the tlv value (same length/value).
- * @param addr pointer to address object
- * @param first true if this is the first address of this message
- */
-static void
-_calculate_tlv_flags(struct rfc5444_writer_address *addr, bool first) {
-  struct rfc5444_writer_addrtlv *tlv;
-
-  if (first) {
-    avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
-      tlv->same_length = false;
-      tlv->same_value = false;
-    }
-    return;
-  }
-
-  avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
-    struct rfc5444_writer_addrtlv *prev = NULL;
-
-    /* check if this is the first tlv of this type */
-    if (avl_is_first(&tlv->tlvtype->_tlv_tree, &tlv->tlv_node)) {
-      tlv->same_length = false;
-      tlv->same_value = false;
-      continue;
-    }
-
-    prev = avl_prev_element(tlv, tlv_node);
-
-    if (tlv->address->index > prev->address->index + 1) {
-      tlv->same_length = false;
-      tlv->same_value = false;
-      continue;
-    }
-
-    /* continous tlvs */
-    tlv->same_length = tlv->length == prev->length;
-    tlv->same_value = tlv->same_length &&
-        (tlv->length == 0 || tlv->value == prev->value
-            || memcmp(tlv->value, prev->value, tlv->length) == 0);
-  }
 }
 
 /**
  * Update the address compression session with a new address.
  *
  * @param acs pointer to address compression session
- * @param msg pointer to message object
- * @param addr pointer to new address
+ * @param writer pointer to rfc5444 writer
+ * @param addr_list list of addresses
  * @param same_prefixlen number of addresses (up to this) with the same
  *   prefix length
- * @param first true if this is the first address of the message
  * @return new number of messages with same prefix length
  */
 static int
-_compress_address(struct _rfc5444_internal_addr_compress_session *acs,
-    struct rfc5444_writer_message *msg, struct rfc5444_writer_address *addr,
-    int same_prefixlen, bool first) {
-  struct rfc5444_writer_address *last_addr = NULL;
-  struct rfc5444_writer_addrtlv *tlv;
-  int i, common_head;
+_compress_address(struct _rfc5444_internal_addr_compress_session *acs, struct rfc5444_writer *writer,
+  struct oonf_list_entity *addr_list, int same_prefixlen) {
+  struct rfc5444_writer_address *addr, *last_addr;
+  struct rfc5444_writer_addrtlv *tlv, *last_tlv;
+  struct rfc5444_writer_tlvtype *tlvtype;
+  uint32_t i, common_head;
   const uint8_t *addrptr, *last_addrptr;
+  int cost, new_cost, continue_cost;
   uint8_t addrlen;
   bool special_prefixlen;
+  bool closed;
 
-  addrlen = msg->addr_len;
+  addr = oonf_list_last_element(addr_list, addr, _addr_fragment_node);
+  if (!oonf_list_is_first(addr_list, &addr->_addr_fragment_node)) {
+    last_addr = oonf_list_prev_element(addr, _addr_fragment_node);
+  }
+  else {
+    last_addr = NULL;
+  }
+
+  addrlen = writer->msg_addr_len;
   common_head = 0;
   special_prefixlen = netaddr_get_prefix_length(&addr->address) != addrlen * 8;
 
   addrptr = netaddr_get_binptr(&addr->address);
 
+#ifdef DEBUG_OUTPUT
+  {
+    struct netaddr_str nbuf1, nbuf2;
+    printf("Compress Address %s (last: %s)\n", netaddr_to_string(&nbuf1, &addr->address),
+      last_addr == NULL ? "" : netaddr_to_string(&nbuf2, &last_addr->address));
+    printf("\ttotal:   ");
+    for (i = 0; i < addrlen; i++) {
+      printf(" %4d ", acs[i].total);
+    }
+    printf("\n");
+  }
+#endif
   /* add size for address part (and header if necessary) */
-  if (!first) {
-    /* get previous address */
-    last_addr = oonf_list_prev_element(addr, _addr_node);
-
+  if (last_addr) {
     /* remember how many entries with the same prefixlength we had */
-    if (netaddr_get_prefix_length(&last_addr->address)
-        == netaddr_get_prefix_length(&addr->address)) {
+    if (netaddr_get_prefix_length(&last_addr->address) == netaddr_get_prefix_length(&addr->address)) {
       same_prefixlen++;
-    } else {
+    }
+    else {
       same_prefixlen = 1;
     }
 
     /* add bytes to continue encodings with same prefix */
-#if DO_ADDR_COMPRESSION == true
     last_addrptr = netaddr_get_binptr(&last_addr->address);
     for (common_head = 0; common_head < addrlen; common_head++) {
       if (last_addrptr[common_head] != addrptr[common_head]) {
         break;
       }
     }
+    _close_addrblock(acs, writer, last_addr, common_head);
+#ifdef DEBUG_OUTPUT
+    printf("\tt-closed:");
+    for (i = 0; i < addrlen; i++) {
+      printf(" %4d ", acs[i].total);
+    }
+    printf("\n");
 #endif
-    _close_addrblock(acs, msg, last_addr, common_head);
+  }
+
+#ifdef DEBUG_OUTPUT
+  printf("\tcurrent:");
+#endif
+
+  /* calculate tlv flags */
+  avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
+    tlvtype = tlv->tlvtype;
+
+    tlv->_same_length = false;
+    tlv->_same_value = false;
+
+    if (last_addr) {
+      last_tlv = avl_find_element(&last_addr->_addrtlv_tree, &tlvtype->_full_type, last_tlv, addrtlv_node);
+      if (last_tlv && last_tlv->length == tlv->length) {
+        tlv->_same_length = true;
+        tlv->_same_value = memcmp(tlv->value, last_tlv->value, tlv->length) == 0;
+      }
+    }
   }
 
   /* calculate new costs for next address including tlvs */
-#if DO_ADDR_COMPRESSION == true
   for (i = 0; i < addrlen; i++) {
-#else
-  i = 0;
-  {
-#endif
-    int new_cost = 0, continue_cost = 0;
-    bool closed = false;
+    new_cost = 0;
+    continue_cost = 0;
+    closed = false;
 
-#if DO_ADDR_COMPRESSION == true
-    closed = first || (i > common_head);
-#else
-    closed = true;
-#endif
+    closed = last_addr == NULL;
+    if (common_head < i) {
+      closed = true;
+    }
     /* cost of new address header */
-    new_cost = 2 + (i > 0 ? 1 : 0) + msg->addr_len;
+    new_cost = 2 + (i > 0 ? 1 : 0) + writer->msg_addr_len;
     if (special_prefixlen) {
       new_cost++;
     }
 
     if (!closed) {
       /* cost of continuing the last address header */
-      continue_cost = msg->addr_len - i;
+      continue_cost = writer->msg_addr_len - i;
       if (acs[i].multiplen) {
         /* will stay multi_prefixlen */
         continue_cost++;
@@ -890,161 +963,243 @@ _compress_address(struct _rfc5444_internal_addr_compress_session *acs,
       }
     }
 
+    /* mandatory TLV block */
+    new_cost += 2;
+
     /* calculate costs for breaking/continuing tlv sequences */
     avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
-      struct rfc5444_writer_tlvtype *tlvtype = tlv->tlvtype;
-      int cost;
+      tlvtype = tlv->tlvtype;
 
-      cost = 2 + (tlv->tlvtype->exttype ? 1 : 0) + 2 + tlv->length;
+      /* type + flags */
+      cost = 2;
+
+      if (tlvtype->exttype > 0) {
+        cost++;
+      }
+
+      /* TODO: dynamic index fields? */
+      cost += 2;
+
       if (tlv->length > 255) {
+        /* 2 byte length field */
         cost++;
       }
       if (tlv->length > 0) {
-          cost++;
+        /* 1 or 2 byte length field */
+        cost++;
       }
 
+      /* value */
+      cost += tlv->length;
+
+      /* add to cost for a new TLV block */
       new_cost += cost;
-      if (!tlv->same_length || closed) {
-        /* this TLV does not continue over the border of an address block */
+
+      /* check if we are forced to do a new tlv block anyways */
+      if (closed || !tlv->_same_length) {
+        /*
+         * this TLV does not continue, either because address block is ending or because
+         * value length changed
+         */
         continue_cost += cost;
         continue;
       }
 
       if (tlvtype->_tlvblock_multi[i]) {
+        /* we are already within a TLV with multiple values, so add another one */
         continue_cost += tlv->length;
       }
-      else if (!tlv->same_value) {
+      else if (!tlv->_same_value) {
+        /* ups, value changed. Change cost estimate to multivalue TLV */
         continue_cost += tlv->length * tlvtype->_tlvblock_count[i];
       }
     }
-
-    if (closed || acs[i].total + continue_cost > acs[addrlen-1].total + new_cost) {
-      /* new address block */
+#ifdef DEBUG_OUTPUT
+    printf(" %2d/%2d", continue_cost, closed ? -1 : new_cost);
+#endif
+    if (closed || acs[i].total + continue_cost > acs[addrlen - 1].total + new_cost) {
+      /* forget the last addresses, longer prefix is better. */
+      /* store address block for later binary generation */
+#if 0
+      if (last_addr) {
+        last_addr->_block_start = acs[addrlen-1].ptr;
+        last_addr->_block_multiple_prefixlen = acs[addrlen-1].multiplen;
+        last_addr->_block_headlen = addrlen-1;
+      }
+#endif
+      /* Create a new address block */
       acs[i].ptr = addr;
       acs[i].multiplen = false;
 
-      acs[i].total = acs[addrlen-1].total;
+      acs[i].total = acs[addrlen - 1].total;
       acs[i].current = new_cost;
-
       closed = true;
     }
     else {
       acs[i].current = continue_cost;
-      closed = false;
+    }
+
+    if (last_addr) {
+      acs[i].closed = closed;
     }
 
     /* update internal tlv calculation */
     avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
-      struct rfc5444_writer_tlvtype *tlvtype = tlv->tlvtype;
-      if (closed) {
+      tlvtype = tlv->tlvtype;
+
+      if (closed || !tlv->_same_length) {
         tlvtype->_tlvblock_count[i] = 1;
         tlvtype->_tlvblock_multi[i] = false;
       }
       else {
         tlvtype->_tlvblock_count[i]++;
-        tlvtype->_tlvblock_multi[i] |= (!tlv->same_value);
+        if (!tlv->_same_value) {
+          tlvtype->_tlvblock_multi[i] = true;
+        }
       }
     }
   }
+#ifdef DEBUG_OUTPUT
+  printf("\n");
+#endif
   return same_prefixlen;
+}
+
+static uint8_t *
+_write_addresstlv(struct rfc5444_writer_tlvtype *tlvtype, struct rfc5444_writer_address *addr_first,
+  struct rfc5444_writer_address *addr_last, uint8_t *ptr) {
+  struct rfc5444_writer_addrtlv *tlv_first, *tlv_last, *tlv;
+  uint16_t total_len;
+  uint8_t *flag;
+
+  /* get edge tlvs */
+  tlv_first = oonf_list_first_element(&tlvtype->_current_tlv_list, tlv_first, _current_tlv_node);
+  tlv_last = oonf_list_last_element(&tlvtype->_current_tlv_list, tlv_first, _current_tlv_node);
+
+  /* write tlv */
+  *ptr++ = tlvtype->type;
+
+  /* remember flag pointer */
+  flag = ptr;
+  *ptr++ = 0;
+  if (tlvtype->exttype) {
+    *flag |= RFC5444_TLV_FLAG_TYPEEXT;
+    *ptr++ = tlvtype->exttype;
+  }
+
+  /* copy original length field */
+  total_len = tlv_first->length;
+
+  if (tlv_first->address == addr_first && tlv_last->address == addr_last) {
+    /* no index necessary */
+  }
+  else if (tlv_first->address->index == tlv_last->address->index) {
+    *flag |= RFC5444_TLV_FLAG_SINGLE_IDX;
+    *ptr++ = tlv_first->address->index - addr_first->index;
+  }
+  else {
+    *flag |= RFC5444_TLV_FLAG_MULTI_IDX;
+    *ptr++ = tlv_first->address->index - addr_first->index;
+    *ptr++ = tlv_last->address->index - addr_first->index;
+  }
+
+  /* length field is single_length*num for multivalue tlvs */
+  if (!tlvtype->_same_value) {
+    total_len = total_len * ((tlv_last->address->index - tlv_first->address->index) + 1);
+    *flag |= RFC5444_TLV_FLAG_MULTIVALUE;
+  }
+
+  /* write length field and corresponding flags */
+  if (total_len > 255) {
+    *flag |= RFC5444_TLV_FLAG_EXTVALUE;
+    *ptr++ = total_len >> 8;
+  }
+  if (total_len > 0) {
+    *flag |= RFC5444_TLV_FLAG_VALUE;
+    *ptr++ = total_len & 255;
+  }
+
+  if (tlv_first->length > 0) {
+    /* write value */
+    if (tlvtype->_same_value) {
+      memcpy(ptr, tlv_first->value, tlv_first->length);
+      ptr += tlv_first->length;
+    }
+    else {
+      oonf_list_for_each_element(&tlvtype->_current_tlv_list, tlv, _current_tlv_node) {
+        memcpy(ptr, tlv->value, tlv->length);
+        ptr += tlv->length;
+      }
+    }
+  }
+  return ptr;
 }
 
 /**
  * Write the address-TLVs of a specific type
- * @param addr_start first address for TLVs
- * @param addr_end last address for TLVs
- * @param tlvtype tlvtype to write into buffer
+ * @param writer RFC5444 writer instance
+ * @param msg RFC5444 message to be generated
+ * @param first first address for TLVs
+ * @param last last address for TLVs
  * @param ptr target buffer pointer
  * @return modified target buffer pointer
  */
 static uint8_t *
-_write_tlvtype(struct rfc5444_writer_address *addr_start, struct rfc5444_writer_address *addr_end,
-    struct rfc5444_writer_tlvtype *tlvtype, uint8_t *ptr) {
-  struct rfc5444_writer_addrtlv *tlv_start, *tlv_end, *tlv;
-  uint16_t total_len;
-  uint8_t *flag;
+_write_addresstlvs(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
+  struct rfc5444_writer_address *first, struct rfc5444_writer_address *last, uint8_t *ptr) {
+  struct rfc5444_writer_tlvtype *tlvtype;
+  struct rfc5444_writer_address *addr, *prev_addr;
+  struct rfc5444_writer_addrtlv *tlv, *last_tlv;
+  struct oonf_list_entity active_tlvtypes;
 
-  /* find first/last tlv for this address block */
-  tlv_start = avl_find_ge_element(&tlvtype->_tlv_tree, &addr_start->_orig_index, tlv_start, tlv_node);
+  /* clear markers for tlv blocks */
+  oonf_list_for_each_element(&msg->_msgspecific_tlvtype_head, tlvtype, _tlvtype_node) {
+    oonf_list_init_head(&tlvtype->_current_tlv_list);
+  }
+  oonf_list_for_each_element(&writer->_addr_tlvtype_head, tlvtype, _tlvtype_node) {
+    oonf_list_init_head(&tlvtype->_current_tlv_list);
+  }
 
-  while (tlv_start != NULL && tlv_start->address->_orig_index <= addr_end->_orig_index) {
-    bool same_value;
+  oonf_list_init_head(&active_tlvtypes);
 
-    /* get end of local TLV-Block and value-mode */
-    same_value = true;
-    tlv_end = tlv_start;
+  /* loop over all addresses */
+  prev_addr = NULL;
+  oonf_list_for_element_range(first, last, addr, _addr_fragment_node) {
+    avl_for_each_element(&addr->_addrtlv_tree, tlv, addrtlv_node) {
+      tlvtype = tlv->tlvtype;
 
-    avl_for_element_to_last(&tlvtype->_tlv_tree, tlv_start, tlv, tlv_node) {
-      if (tlv != tlv_start && tlv->address->index <= addr_end->index) {
-        if (!tlv->same_length) {
-          /* sequence of TLVs got interrupted */
-          break;
+      if (!oonf_list_is_empty(&tlvtype->_current_tlv_list)) {
+        last_tlv = oonf_list_last_element(&tlvtype->_current_tlv_list, last_tlv, _current_tlv_node);
+
+        if (last_tlv->address != prev_addr || last_tlv->length != tlv->length) {
+          /* we need to end this TLV and start a new one */
+          ptr = _write_addresstlv(tlvtype, first, last, ptr);
+
+          /* clear list of tlvs of this type */
+          oonf_list_init_head(&tlvtype->_current_tlv_list);
+          tlvtype->_same_value = true;
         }
-        tlv_end = tlv;
-        same_value &= tlv->same_value;
-      }
-    }
-
-    /* write tlv */
-    *ptr++ = tlvtype->type;
-
-    /* remember flag pointer */
-    flag = ptr;
-    *ptr++ = 0;
-    if (tlvtype->exttype) {
-      *flag |= RFC5444_TLV_FLAG_TYPEEXT;
-      *ptr++ = tlvtype->exttype;
-    }
-
-    /* copy original length field */
-    total_len = tlv_start->length;
-
-    if (tlv_start->address == addr_start && tlv_end->address == addr_end) {
-      /* no index necessary */
-    } else if (tlv_start == tlv_end) {
-      *flag |= RFC5444_TLV_FLAG_SINGLE_IDX;
-      *ptr++ = tlv_start->address->index - addr_start->index;
-    } else {
-      *flag |= RFC5444_TLV_FLAG_MULTI_IDX;
-      *ptr++ = tlv_start->address->index - addr_start->index;
-      *ptr++ = tlv_end->address->index - addr_start->index;
-    }
-
-    /* length field is single_length*num for multivalue tlvs */
-    if (!same_value) {
-      total_len = total_len * ((tlv_end->address->index - tlv_start->address->index) + 1);
-      *flag |= RFC5444_TLV_FLAG_MULTIVALUE;
-    }
-
-
-    /* write length field and corresponding flags */
-    if (total_len > 255) {
-      *flag |= RFC5444_TLV_FLAG_EXTVALUE;
-      *ptr++ = total_len >> 8;
-    }
-    if (total_len > 0) {
-      *flag |= RFC5444_TLV_FLAG_VALUE;
-      *ptr++ = total_len & 255;
-    }
-
-    if (tlv_start->length > 0) {
-      /* write value */
-      if (same_value) {
-        memcpy(ptr, tlv_start->value, tlv_start->length);
-        ptr += tlv_start->length;
-      } else {
-        avl_for_element_range(tlv_start, tlv_end, tlv, tlv_node) {
-          memcpy(ptr, tlv->value, tlv->length);
-          ptr += tlv->length;
+        else {
+          /* keep track if the value stays the same */
+          tlvtype->_same_value &= tlv->_same_value;
         }
       }
+      else {
+        /* this tlvtype is now active */
+        oonf_list_add_tail(&active_tlvtypes, &tlvtype->_active_tlv_node);
+        tlvtype->_same_value = true;
+      }
+
+      /* add current tlv to list */
+      oonf_list_add_tail(&tlvtype->_current_tlv_list, &tlv->_current_tlv_node);
     }
 
-    if (avl_is_last(&tlvtype->_tlv_tree, &tlv_end->tlv_node)) {
-      tlv_start = NULL;
-    } else {
-      tlv_start = avl_next_element(tlv_end, tlv_node);
-    }
+    /* remember last address for next loop iteration */
+    prev_addr = addr;
+  }
+
+  oonf_list_for_each_element(&active_tlvtypes, tlvtype, _active_tlv_node) {
+    ptr = _write_addresstlv(tlvtype, first, last, ptr);
   }
   return ptr;
 }
@@ -1053,44 +1208,60 @@ _write_tlvtype(struct rfc5444_writer_address *addr_start, struct rfc5444_writer_
  * Write the address blocks to the message buffer.
  * @param writer pointer to writer context
  * @param msg pointer to message context
- * @param first_addr pointer to first address to be written
- * @param last_addr pointer to last address to be written
+ * @param fragment_addrs list of fragmented addresses
  */
 static void
-_write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
-    struct rfc5444_writer_address *first_addr, struct rfc5444_writer_address *last_addr) {
-  struct rfc5444_writer_address *addr_start, *addr_end, *addr;
-  struct rfc5444_writer_tlvtype *tlvtype;
+_write_addresses(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, struct oonf_list_entity *fragment_addrs) {
+  struct rfc5444_writer_address *addr_start, *addr_end, *addr_first, *addr_last, *addr;
   const uint8_t *addr_start_ptr, *addr_ptr;
   uint8_t *start, *ptr, *flag, *tlvblock_length;
+  uint8_t head_len, tail_len, mid_len;
+  bool zero_tail;
+#ifdef DEBUG_OUTPUT
+  uint8_t *debug_ptr;
+#endif
 
-  assert(first_addr->_block_end);
+  addr_first = oonf_list_first_element(fragment_addrs, addr_first, _addr_fragment_node);
+  addr_last = oonf_list_last_element(fragment_addrs, addr_last, _addr_fragment_node);
 
-  addr_start = first_addr;
+  assert(addr_first->_block_end);
+
+  addr_start = addr_first;
   ptr = &writer->_msg.buffer[writer->_msg.header + writer->_msg.added + writer->_msg.allocated];
 
   /* remember start */
   start = ptr;
 
+#ifdef DEBUG_OUTPUT
+  debug_ptr = ptr;
+#endif
+
   /* loop through address blocks */
   do {
-    uint8_t head_len = 0, tail_len = 0, mid_len = 0;
-#if DO_ADDR_COMPRESSION == true
-    bool zero_tail = false;
-#endif
+    head_len = 0;
+    tail_len = 0;
+    mid_len = 0;
+    zero_tail = false;
 
     addr_start_ptr = netaddr_get_binptr(&addr_start->address);
     addr_end = addr_start->_block_end;
 
-#if DO_ADDR_COMPRESSION == true
+#ifdef DEBUG_OUTPUT
+    {
+      struct netaddr_str nbuf1, nbuf2;
+      printf("Write address block from %s to %s\n", netaddr_to_string(&nbuf1, &addr_start->address),
+        netaddr_to_string(&nbuf2, &addr_end->address));
+    }
+#endif
     if (addr_start != addr_end) {
       /* only use head/tail for address blocks with multiple addresses */
-      int tail;
+      uint8_t tail;
       head_len = addr_start->_block_headlen;
-      tail_len = msg->addr_len - head_len - 1;
+      tail_len = writer->msg_addr_len - head_len - 1;
 
       /* calculate tail length and netmask length */
-      oonf_list_for_element_range(addr_start, addr_end, addr, _addr_node) {
+      oonf_list_for_element_range(addr_start, addr_end, addr, _addr_fragment_node) {
         addr_ptr = netaddr_get_binptr(&addr->address);
 
         /* stop if no tail is left */
@@ -1099,7 +1270,7 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
         }
 
         for (tail = 1; tail <= tail_len; tail++) {
-          if (addr_start_ptr[msg->addr_len - tail] != addr_ptr[msg->addr_len - tail]) {
+          if (addr_start_ptr[writer->msg_addr_len - tail] != addr_ptr[writer->msg_addr_len - tail]) {
             tail_len = tail - 1;
             break;
           }
@@ -1108,13 +1279,13 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
 
       zero_tail = tail_len > 0;
       for (tail = 0; zero_tail && tail < tail_len; tail++) {
-        if (addr_start_ptr[msg->addr_len - tail - 1] != 0) {
+        if (addr_start_ptr[writer->msg_addr_len - tail - 1] != 0) {
           zero_tail = false;
         }
       }
     }
-#endif
-    mid_len = msg->addr_len - head_len - tail_len;
+
+    mid_len = writer->msg_addr_len - head_len - tail_len;
 
     /* write addrblock header */
     *ptr++ = addr_end->index - addr_start->index + 1;
@@ -1123,7 +1294,6 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
     flag = ptr;
     *ptr++ = 0;
 
-#if DO_ADDR_COMPRESSION == true
     /* write head */
     if (head_len) {
       *flag |= RFC5444_ADDR_FLAG_HEAD;
@@ -1137,15 +1307,16 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
       *ptr++ = tail_len;
       if (zero_tail) {
         *flag |= RFC5444_ADDR_FLAG_ZEROTAIL;
-      } else {
+      }
+      else {
         *flag |= RFC5444_ADDR_FLAG_FULLTAIL;
-        memcpy(ptr, &addr_start_ptr[msg->addr_len - tail_len], tail_len);
+        memcpy(ptr, &addr_start_ptr[writer->msg_addr_len - tail_len], tail_len);
         ptr += tail_len;
       }
     }
-#endif
+
     /* loop through addresses in block for MID part */
-    oonf_list_for_element_range(addr_start, addr_end, addr, _addr_node) {
+    oonf_list_for_element_range(addr_start, addr_end, addr, _addr_fragment_node) {
       addr_ptr = netaddr_get_binptr(&addr->address);
       memcpy(ptr, &addr_ptr[head_len], mid_len);
       ptr += mid_len;
@@ -1155,33 +1326,36 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
     if (addr_start->_block_multiple_prefixlen) {
       /* multiple prefixlen */
       *flag |= RFC5444_ADDR_FLAG_MULTIPLEN;
-      oonf_list_for_element_range(addr_start, addr_end, addr, _addr_node) {
+      oonf_list_for_element_range(addr_start, addr_end, addr, _addr_fragment_node) {
         *ptr++ = netaddr_get_prefix_length(&addr->address);
       }
-    } else if (netaddr_get_prefix_length(&addr_start->address)!= msg->addr_len * 8) {
+    }
+    else if (netaddr_get_prefix_length(&addr_start->address) != writer->msg_addr_len * 8) {
       /* single prefixlen */
       *flag |= RFC5444_ADDR_FLAG_SINGLEPLEN;
       *ptr++ = netaddr_get_prefix_length(&addr_start->address);
     }
 
+#ifdef DEBUG_OUTPUT
+    printf("Generated %zd bytes for address block\n", ptr - debug_ptr);
+    debug_ptr = ptr;
+#endif
+
     /* remember pointer for tlvblock length */
     tlvblock_length = ptr;
     ptr += 2;
 
-    /* loop through all message specific address-tlv types */
-    oonf_list_for_each_element(&msg->_msgspecific_tlvtype_head, tlvtype, _tlvtype_node) {
-      ptr = _write_tlvtype(addr_start, addr_end, tlvtype, ptr);
-    }
-
-    /* look through  all generic address-tlv types */
-    oonf_list_for_each_element(&writer->_addr_tlvtype_head, tlvtype, _tlvtype_node) {
-      ptr = _write_tlvtype(addr_start, addr_end, tlvtype, ptr);
-    }
+    /* generate tlvs */
+    ptr = _write_addresstlvs(writer, msg, addr_start, addr_end, ptr);
 
     tlvblock_length[0] = (ptr - tlvblock_length - 2) >> 8;
     tlvblock_length[1] = (ptr - tlvblock_length - 2) & 255;
-    addr_start = oonf_list_next_element(addr_end, _addr_node);
-  } while (addr_end != last_addr);
+    addr_start = oonf_list_next_element(addr_end, _addr_fragment_node);
+#ifdef DEBUG_OUTPUT
+    printf("Generated %zd bytes for address tlvs\n", ptr - debug_ptr);
+    debug_ptr = ptr;
+#endif
+  } while (addr_end != addr_last);
 
   /* store size of address(tlv) data */
   msg->_bin_addr_size = ptr - start;
@@ -1190,7 +1364,7 @@ _write_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
 /**
  * Write header of message including mandatory tlvblock length field.
  * @param writer pointer to writer context
- * @param _msg pointer to message object
+ * @param msg pointer to message object
  */
 static void
 _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg) {
@@ -1203,7 +1377,7 @@ _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
 
   /* flags & addrlen */
   flags = ptr;
-  *ptr++ = msg->addr_len - 1;
+  *ptr++ = writer->msg_addr_len - 1;
 
   /* size */
   total_size = writer->_msg.header + writer->_msg.added + writer->_msg.set + msg->_bin_addr_size;
@@ -1212,8 +1386,8 @@ _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
 
   if (msg->has_origaddr) {
     *flags |= RFC5444_MSG_FLAG_ORIGINATOR;
-    memcpy(ptr, msg->orig_addr, msg->addr_len);
-    ptr += msg->addr_len;
+    memcpy(ptr, msg->orig_addr, writer->msg_addr_len);
+    ptr += writer->msg_addr_len;
   }
   if (msg->has_hoplimit) {
     *flags |= RFC5444_MSG_FLAG_HOPLIMIT;
@@ -1239,20 +1413,22 @@ _write_msgheader(struct rfc5444_writer *writer, struct rfc5444_writer_message *m
  * Finalize a message fragment, copy it into the packet buffer and
  * cleanup message internal data.
  * @param writer pointer to writer context
- * @param _msg pointer to message object
- * @param first pointer to first address of this fragment
- * @param last pointer to last address of this fragment
+ * @param msg pointer to message object
+ * @param fragment_addrs list of fragmented addresses
  * @param not_fragmented true if this is the only fragment of this message
  * @param useIf pointer to callback for selecting outgoing _targets
+ * @param param custom parameter for callback
  */
 static void
 _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
-    struct rfc5444_writer_address *first, struct rfc5444_writer_address *last, bool not_fragmented,
-    rfc5444_writer_targetselector useIf, void *param) {
+  struct oonf_list_entity *fragment_addrs, bool not_fragmented, rfc5444_writer_targetselector useIf, void *param) {
+  struct rfc5444_writer_postprocessor *processor;
   struct rfc5444_writer_content_provider *prv;
-  struct rfc5444_writer_target *interface;
+  struct rfc5444_writer_target *target;
+  struct rfc5444_writer_address *addr, *first, *last;
   uint8_t *ptr;
-  size_t len;
+  size_t msg_minsize, msg_size, generic_size;
+  bool error;
 
   /* reset optional tlv length */
   writer->_msg.set = 0;
@@ -1261,6 +1437,14 @@ _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_
   writer->_state = RFC5444_WRITER_FINISH_MSGTLV;
 #endif
 
+  if (!oonf_list_is_empty(fragment_addrs)) {
+    first = oonf_list_first_element(fragment_addrs, first, _addr_fragment_node);
+    last = oonf_list_last_element(fragment_addrs, last, _addr_fragment_node);
+  }
+  else {
+    first = last = NULL;
+  }
+
   /* inform message providers */
   avl_for_each_element_reverse(&msg->_provider_tree, prv, _provider_node) {
     if (prv->finishMessageTLVs) {
@@ -1268,8 +1452,25 @@ _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_
     }
   }
 
-  if (first != NULL && last != NULL) {
-    _write_addresses(writer, msg, first, last);
+  if (!oonf_list_is_empty(fragment_addrs)) {
+    addr = last;
+
+    /* generate forward pointers */
+    while (true) {
+      addr->_block_start->_block_end = addr;
+      addr->_block_start->_block_multiple_prefixlen = addr->_block_multiple_prefixlen;
+      addr->_block_start->_block_headlen = addr->_block_headlen;
+      if (addr->_block_start == first) {
+        break;
+      }
+
+      /* consistency check */
+      assert(addr->_block_start->index > first->index);
+
+      /* get address block before this one */
+      addr = oonf_list_prev_element(addr->_block_start, _addr_fragment_node);
+    }
+    _write_addresses(writer, msg, fragment_addrs);
   }
 
 #if WRITER_STATE_MACHINE == true
@@ -1289,40 +1490,82 @@ _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_
 #endif
 
   /* precalculate number of fixed bytes of message header */
-  len = writer->_msg.header + writer->_msg.added;
+  msg_minsize = writer->_msg.header + writer->_msg.added;
 
-  oonf_list_for_each_element(&writer->_targets, interface, _target_node) {
+  /* 1.) first flush all interfaces that have full buffers */
+  oonf_list_for_each_element(&writer->_targets, target, _target_node) {
     /* do we need to handle this interface ? */
-    if (!useIf(writer, interface, param)) {
+    if (!useIf(writer, target, param)) {
       continue;
     }
 
     /* calculate total size of packet and message, see if it fits into the current packet */
-    if (interface->_pkt.header + interface->_pkt.added + interface->_pkt.set + interface->_bin_msgs_size
-        + writer->_msg.header + writer->_msg.added + writer->_msg.set + msg->_bin_addr_size
-        > interface->_pkt.max) {
-
+    if (target->_pkt.header + target->_pkt.added + target->_pkt.set + target->_bin_msgs_size + writer->_msg.header +
+          writer->_msg.added + writer->_msg.set + msg->_bin_addr_size >
+        target->_pkt.max) {
       /* flush the old packet */
-      rfc5444_writer_flush(writer, interface, false);
+      rfc5444_writer_flush(writer, target, false);
 
       /* begin a new one */
-      _rfc5444_writer_begin_packet(writer, interface);
+      _rfc5444_writer_begin_packet(writer, target);
+    }
+  }
+
+  /* 2.) generate message and do non-target specific post processors */
+
+  /* copy message header and message tlvs into packet buffer */
+  ptr = _msg_buffer;
+  memcpy(ptr, writer->_msg.buffer, msg_minsize + writer->_msg.set);
+
+  /* copy address blocks and address tlvs into packet buffer */
+  ptr += msg_minsize + writer->_msg.set;
+  memcpy(ptr, &writer->_msg.buffer[msg_minsize + writer->_msg.allocated], msg->_bin_addr_size);
+
+  /* remember position of first copy */
+  generic_size = msg_minsize + writer->_msg.set + msg->_bin_addr_size;
+
+  /* run processors */
+  avl_for_each_element(&writer->_processors, processor, _node) {
+    if (processor->is_matching_signature(processor, msg->type) && !processor->target_specific) {
+      if (processor->process(processor, target, msg, _msg_buffer, &generic_size)) {
+        /* error, we have not modified the _bin_msgs_size, so we can just return */
+        return;
+      }
+    }
+  }
+
+  /* 3.) generate target specific messages and add them to the buffers */
+  oonf_list_for_each_element(&writer->_targets, target, _target_node) {
+    /* do we need to handle this interface ? */
+    if (!useIf(writer, target, param)) {
+      continue;
     }
 
+    /* get pointer to end of _pkt buffer  and copy it */
+    ptr =
+      &target->_pkt.buffer[target->_pkt.header + target->_pkt.added + target->_pkt.allocated + target->_bin_msgs_size];
+    memcpy(ptr, _msg_buffer, generic_size);
 
-    /* get pointer to end of _pkt buffer */
-    ptr = &interface->_pkt.buffer[interface->_pkt.header + interface->_pkt.added
-                                 + interface->_pkt.allocated + interface->_bin_msgs_size];
+    /* now run the target specific processors */
+    msg_size = generic_size;
+    error = false;
+    avl_for_each_element(&writer->_processors, processor, _node) {
+      if (processor->is_matching_signature(processor, msg->type) && processor->target_specific && msg_size > 0) {
+        if (processor->process(processor, target, msg, ptr, &msg_size)) {
+          error = true;
+          break;
+        }
+      }
+    }
 
-    /* copy message header and message tlvs into packet buffer */
-    memcpy(ptr, writer->_msg.buffer, len + writer->_msg.set);
+    if (!error && msg_size > 0) {
+      /* increase byte count of packet */
+      target->_bin_msgs_size += msg_size;
 
-    /* copy address blocks and address tlvs into packet buffer */
-    ptr += len + writer->_msg.set;
-    memcpy(ptr, &writer->_msg.buffer[len + writer->_msg.allocated], msg->_bin_addr_size);
-
-    /* increase byte count of packet */
-    interface->_bin_msgs_size += len + writer->_msg.set + msg->_bin_addr_size;
+      if (writer->message_generation_notifier) {
+        writer->message_generation_notifier(target);
+      }
+    }
   }
 
   /* clear length value of message address size */
@@ -1333,6 +1576,6 @@ _finalize_message_fragment(struct rfc5444_writer *writer, struct rfc5444_writer_
 
   /* clear message buffer */
 #if DEBUG_CLEANUP == true
-  memset(&writer->_msg.buffer[len], 0, writer->_msg.max - len);
+  memset(&writer->_msg.buffer[msg_minsize], 253, writer->_msg.max - msg_minsize);
 #endif
 }

--- a/sys/oonf_api/rfc5444/rfc5444_tlv_writer.c
+++ b/sys/oonf_api/rfc5444/rfc5444_tlv_writer.c
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,15 +39,20 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #include <string.h>
 
-#include "rfc5444/rfc5444_tlv_writer.h"
-#include "rfc5444/rfc5444_context.h"
-#include "rfc5444/rfc5444_api_config.h"
+#include "common/common_types.h"
+#include "rfc5444_api_config.h"
+#include "rfc5444_context.h"
+#include "rfc5444_tlv_writer.h"
 
-static size_t _calc_tlv_size(bool exttype, size_t length);
-static void _write_tlv(uint8_t *ptr, uint8_t type, uint8_t exttype,
-    uint8_t idx1, uint8_t idx2, const void *value, size_t length);
+static size_t _calc_tlv_size(bool has_exttype, size_t length);
+static void _write_tlv(
+  uint8_t *ptr, uint8_t type, uint8_t exttype, uint8_t idx1, uint8_t idx2, const void *value, size_t length);
 
 /**
  * Internal function to initialize a data buffer (message or packet)
@@ -59,8 +64,7 @@ static void _write_tlv(uint8_t *ptr, uint8_t type, uint8_t exttype,
  * @param mtu number of bytes of allocated buffer
  */
 void
-_rfc5444_tlv_writer_init(struct rfc5444_tlv_writer_data *data, size_t max,
-    size_t mtu __attribute__ ((unused))) {
+_rfc5444_tlv_writer_init(struct rfc5444_tlv_writer_data *data, size_t max, size_t mtu __attribute__((unused))) {
   data->header = 0;
   data->added = 0;
   data->allocated = 0;
@@ -84,8 +88,9 @@ _rfc5444_tlv_writer_init(struct rfc5444_tlv_writer_data *data, size_t max,
  * @return RFC5444_OKAY if tlv has been added to buffer, RFC5444_... otherwise
  */
 enum rfc5444_result
-_rfc5444_tlv_writer_add(struct rfc5444_tlv_writer_data *data,
-    uint8_t type, uint8_t exttype, const void *value, size_t length) {
+_rfc5444_tlv_writer_add(
+  struct rfc5444_tlv_writer_data *data, uint8_t type, uint8_t exttype, const void *value, size_t length)
+{
   size_t s;
 
   s = _calc_tlv_size(exttype != 0, length);
@@ -97,7 +102,6 @@ _rfc5444_tlv_writer_add(struct rfc5444_tlv_writer_data *data,
   _write_tlv(&data->buffer[data->header + data->added], type, exttype, 0, 255, value, length);
   data->added += s;
   return RFC5444_OKAY;
-
 }
 
 /**
@@ -110,8 +114,8 @@ _rfc5444_tlv_writer_add(struct rfc5444_tlv_writer_data *data,
  * @return RFC5444_OKAY if tlv has been added to buffer, RFC5444_... otherwise
  */
 enum rfc5444_result
-_rfc5444_tlv_writer_allocate(struct rfc5444_tlv_writer_data *data,
-    bool has_exttype, size_t length) {
+_rfc5444_tlv_writer_allocate(struct rfc5444_tlv_writer_data *data, bool has_exttype, size_t length)
+{
   size_t s;
 
   s = _calc_tlv_size(has_exttype, length);
@@ -136,8 +140,9 @@ _rfc5444_tlv_writer_allocate(struct rfc5444_tlv_writer_data *data,
  * @return RFC5444_OKAY if tlv has been added to buffer, RFC5444_... otherwise
  */
 enum rfc5444_result
-_rfc5444_tlv_writer_set(struct rfc5444_tlv_writer_data *data,
-    uint8_t type, uint8_t exttype, const void *value, size_t length) {
+_rfc5444_tlv_writer_set(
+  struct rfc5444_tlv_writer_data *data, uint8_t type, uint8_t exttype, const void *value, size_t length)
+{
   size_t s;
 
   s = _calc_tlv_size(exttype != 0, length);
@@ -157,9 +162,10 @@ _rfc5444_tlv_writer_set(struct rfc5444_tlv_writer_data *data,
  * @param length number of bytes of tlv value, 0 if no value
  * @return number of bytes for TLV including header
  */
-static size_t _calc_tlv_size(bool exttype, size_t length) {
+static size_t
+_calc_tlv_size(bool has_exttype, size_t length) {
   size_t s = 2;
-  if (exttype) {
+  if (has_exttype) {
     s++;
   }
 
@@ -178,15 +184,14 @@ static size_t _calc_tlv_size(bool exttype, size_t length) {
  * This function does NOT do a length check before writing
  * @param ptr pointer to buffer
  * @param type tlv type
- * @param has_exttype extended tlv type, 0 if no extended type
+ * @param exttype extended tlv type, 0 if no extended type
  * @param idx1 lower index of tlv in address block, 0 if no address tlv
  * @param idx2 upper index of tlv in address block, 255 if no address tlv
  * @param value pointer to tlv value, NULL if no value
  * @param length number of bytes in tlv value, 0 if no value
  */
 static void
-_write_tlv(uint8_t *ptr, uint8_t type, uint8_t exttype,
-    uint8_t idx1, uint8_t idx2, const void *value, size_t length) {
+_write_tlv(uint8_t *ptr, uint8_t type, uint8_t exttype, uint8_t idx1, uint8_t idx2, const void *value, size_t length) {
   uint8_t flags = 0;
 
   /* calculate flags field */
@@ -205,7 +210,6 @@ _write_tlv(uint8_t *ptr, uint8_t type, uint8_t exttype,
   if (length > 0) {
     flags |= RFC5444_TLV_FLAG_VALUE;
   }
-
 
   *ptr++ = type;
   *ptr++ = flags;

--- a/sys/oonf_api/rfc5444/rfc5444_tlv_writer.h
+++ b/sys/oonf_api/rfc5444/rfc5444_tlv_writer.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,29 +39,45 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef RFC5444_TLV_WRITER_H_
 #define RFC5444_TLV_WRITER_H_
 
-#include <stdint.h>
-#include <stdbool.h>
+#include "common/common_types.h"
 
+/**
+ * tlv write session
+ */
 struct rfc5444_tlv_writer_data {
+  /*! pointer to binary buffer */
   uint8_t *buffer;
+
+  /*! size of header */
   size_t header;
+
+  /*! size of added TLVs */
   size_t added;
+
+  /*! size of allocated TLVs */
   size_t allocated;
+
+  /*! size of set TLVs */
   size_t set;
+
+  /*! maximum size allowed for TLVs */
   size_t max;
 };
 
 /* internal functions that are not exported to the user */
 void _rfc5444_tlv_writer_init(struct rfc5444_tlv_writer_data *data, size_t max, size_t mtu);
 
-enum rfc5444_result _rfc5444_tlv_writer_add(struct rfc5444_tlv_writer_data *data,
-    uint8_t type, uint8_t exttype, const void *value, size_t length);
-enum rfc5444_result _rfc5444_tlv_writer_allocate(struct rfc5444_tlv_writer_data *data,
-    bool has_exttype, size_t length);
-enum rfc5444_result _rfc5444_tlv_writer_set(struct rfc5444_tlv_writer_data *data,
-    uint8_t type, uint8_t exttype, const void *value, size_t length);
+enum rfc5444_result _rfc5444_tlv_writer_add(
+  struct rfc5444_tlv_writer_data *data, uint8_t type, uint8_t exttype, const void *value, size_t length);
+enum rfc5444_result _rfc5444_tlv_writer_allocate(struct rfc5444_tlv_writer_data *data, bool has_exttype, size_t length);
+enum rfc5444_result _rfc5444_tlv_writer_set(
+  struct rfc5444_tlv_writer_data *data, uint8_t type, uint8_t exttype, const void *value, size_t length);
 
 #endif /* RFC5444_TLV_WRITER_H_ */

--- a/sys/oonf_api/rfc5444/rfc5444_writer.h
+++ b/sys/oonf_api/rfc5444/rfc5444_writer.h
@@ -1,7 +1,7 @@
 
 /*
  * The olsr.org Optimized Link-State Routing daemon version 2 (olsrd2)
- * Copyright (c) 2004-2013, the olsr.org team - see HISTORY file
+ * Copyright (c) 2004-2015, the olsr.org team - see HISTORY file
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -39,6 +39,10 @@
  *
  */
 
+/**
+ * @file
+ */
+
 #ifndef RFC5444_WRITER_H_
 #define RFC5444_WRITER_H_
 
@@ -46,25 +50,20 @@ struct rfc5444_writer;
 struct rfc5444_writer_message;
 
 #include "common/avl.h"
+#include "common/common_types.h"
 #include "common/list.h"
 #include "common/netaddr.h"
-#include "rfc5444/rfc5444_context.h"
-#include "rfc5444/rfc5444_reader.h"
-#include "rfc5444/rfc5444_tlv_writer.h"
-/*
- * Macros to iterate over existing addresses in a message(fragment)
- * during message generation (finishMessageHeader/finishMessageTLVs
- * callbacks)
- */
-#define for_each_fragment_address(first, last, address, loop) oonf_list_for_element_range(first, last, address, addr_node, loop)
-#define for_each_message_address(message, address, loop) oonf_list_for_each_element(&message->addr_head, address, addr_node, loop)
+#include "rfc5444_context.h"
+#include "rfc5444_reader.h"
+#include "rfc5444_tlv_writer.h"
 
 /**
  * state machine values for the writer.
  * If compiled with WRITE_STATE_MACHINE, this can check if the functions
  * of the writer are called from the right context.
  */
-enum rfc5444_internal_state {
+enum rfc5444_internal_state
+{
   RFC5444_WRITER_NONE,
   RFC5444_WRITER_ADD_PKTHEADER,
   RFC5444_WRITER_ADD_PKTTLV,
@@ -77,42 +76,56 @@ enum rfc5444_internal_state {
   RFC5444_WRITER_FINISH_PKTHEADER
 };
 
+enum
+{
+  /*! Maximum packet size for this RFC5444 multiplexer */
+  RFC5444_MAX_PACKET_SIZE = 1500 - 20 - 8,
+
+  /**
+   * Maximum message size for this RFC5444 multiplexer
+   * (minimal ipv6 mtu - ipv6/udp/rfc5444packet/vlan-header)
+   */
+  RFC5444_MAX_MESSAGE_SIZE = 1280 - 40 - 8 - 3 - 4,
+
+  /*! msg_type id for packet post-processor */
+  RFC5444_WRITER_PKT_POSTPROCESSOR = -1,
+};
+
 /**
  * This INTERNAL struct represents a single address tlv
  * of an address during message serialization.
  */
 struct rfc5444_writer_addrtlv {
-  /* tree _target_node of tlvs of a certain type/exttype */
-  struct avl_node tlv_node;
-
-  /* backpointer to tlvtype */
+  /*! backpointer to tlvtype */
   struct rfc5444_writer_tlvtype *tlvtype;
 
-  /* tree _target_node of tlvs used by a single address */
+  /*! tree _target_node of tlvs used by a single address */
   struct avl_node addrtlv_node;
 
-  /* backpointer to address */
+  /*! backpointer to address */
   struct rfc5444_writer_address *address;
 
   /* tlv type and extension is stored in writer_tlvtype */
 
-  /* tlv value length */
+  /*! tlv value length */
   uint16_t length;
 
-  /*
+  /**
    * if multiple tlvs with the same type/ext have the same
-   * value for a continous block of addresses, they should
+   * value for a continuous block of addresses, they should
    * use the same storage for the value (the pointer should
    * be the same)
    */
   void *value;
 
-  /*
-   * true if the TLV has the same length/value for the
-   * address before this one too
-   */
-  bool same_length;
-  bool same_value;
+  /*! addresstlv has same value than for last address */
+  bool _same_value;
+
+  /*! addresstlv has same length than for last address */
+  bool _same_length;
+
+  /*! hook into current list of nodes */
+  struct oonf_list_entity _current_tlv_node;
 };
 
 /**
@@ -120,31 +133,40 @@ struct rfc5444_writer_addrtlv {
  * message creation.
  */
 struct rfc5444_writer_address {
-  /* index of the address */
-  int index;
+  /*! index of the address */
+  uint32_t index;
 
-  /* address/prefix */
+  /*! address/prefix */
   struct netaddr address;
 
-  /* node of address list in writer_message */
-  struct oonf_list_entity _addr_node;
+  /*! node of address list in writer_message */
+  struct oonf_list_entity _addr_oonf_list_node;
 
-  /* node for quick access ( O(log n)) to addresses */
+  /*! node of address list for current fragment */
+  struct oonf_list_entity _addr_fragment_node;
+
+  /*! node for quick access ( O(log n)) to addresses */
   struct avl_node _addr_tree_node;
 
-  /* tree to connect all TLVs of this address */
+  /*! tree to connect all TLVs of this address */
   struct avl_tree _addrtlv_tree;
 
-  /* address block with same prefix/prefixlen until certain address */
-  struct rfc5444_writer_address *_block_end;
+  /*! address block head length */
   uint8_t _block_headlen;
+
+  /*! true if addresses have multiple prefix lengths */
   bool _block_multiple_prefixlen;
 
-  /* original index of the address when it was added to the output list */
-  int _orig_index;
+  /*! pointer to end of the block, NULL if this is not the start address */
+  struct rfc5444_writer_address *_block_end;
 
-  /* handle mandatory addresses for message fragmentation */
+  /*! pointer to start of the block, NULL if this is not the end address */
+  struct rfc5444_writer_address *_block_start;
+
+  /*! true if address is mandatory in all fragments */
   bool _mandatory_addr;
+
+  /*! true if address has already been handled in earlier fragment */
   bool _done;
 };
 
@@ -153,27 +175,35 @@ struct rfc5444_writer_address {
  * to an address of a certain message type.
  */
 struct rfc5444_writer_tlvtype {
-  /* tlv type and extension is stored in writer_tlvtype */
+  /*! tlv type and extension is stored in writer_tlvtype */
   uint8_t type;
 
-  /* tlv extension type */
+  /*! tlv extension type */
   uint8_t exttype;
 
-  /* _target_node of tlvtype list in rfc5444_writer_message */
+  /*! node of tlvtype list in rfc5444_writer_message */
   struct oonf_list_entity _tlvtype_node;
 
-  /* back pointer to message creator */
+  /*! back pointer to message creator */
   struct rfc5444_writer_message *_creator;
 
-  /* head of writer_addrtlv list */
-  struct avl_tree _tlv_tree;
-
-  /* tlv type*256 + tlv_exttype */
+  /*! tlv type*256 + tlv_exttype */
   int _full_type;
 
-  /* internal data for address compression */
+  /*! number of TLVs already compressed for specific head length */
   int _tlvblock_count[RFC5444_MAX_ADDRLEN];
+
+  /*! true if tlv has multiple values for specific head length */
   bool _tlvblock_multi[RFC5444_MAX_ADDRLEN];
+
+  /*! true if tlv has same value */
+  bool _same_value;
+
+  /*! list of active nodes for tlv */
+  struct oonf_list_entity _active_tlv_node;
+
+  /*! list of tlvs for current fragment */
+  struct oonf_list_entity _current_tlv_list;
 };
 
 /**
@@ -181,23 +211,41 @@ struct rfc5444_writer_tlvtype {
  * tlvs for a message context.
  */
 struct rfc5444_writer_content_provider {
-  /* priority of content provider */
-  int priority;
+  /*! priority of content provider */
+  int32_t priority;
 
-  /* message type for this content provider */
+  /*! message type for this content provider */
   uint8_t msg_type;
 
-  /* callbacks for adding tlvs and addresses to a message */
-  void (*addMessageTLVs)(struct rfc5444_writer *);
-  void (*addAddresses)(struct rfc5444_writer *);
-  void (*finishMessageTLVs)(struct rfc5444_writer *,
-    struct rfc5444_writer_address *start,
+  /**
+   * Callback to add message tlvs to message
+   * @param writer rfc5444 writer
+   */
+  void (*addMessageTLVs)(struct rfc5444_writer *writer);
+
+  /**
+   * Callback to add addresses with TLVs to message
+   * @param writer rfc5444 writer
+   */
+  void (*addAddresses)(struct rfc5444_writer *writer);
+
+  /**
+   * Callback to notify that all addresses have been written
+   * and user can now set the earlier allocated message tlvs.
+   * This is called once per message fragment
+   * @param writer rfc5444 writer
+   * @param start first address of fragment
+   * @param end last address of fragment
+   * @param complete false if message has been fragmented,
+   *    true if message fit into MTU
+   */
+  void (*finishMessageTLVs)(struct rfc5444_writer *writer, struct rfc5444_writer_address *start,
     struct rfc5444_writer_address *end, bool complete);
 
-  /* node for tree of content providers for a message creator */
+  /*! node for tree of content providers for a message creator */
   struct avl_node _provider_node;
 
-  /* back pointer to message creator */
+  /*! back pointer to message creator */
   struct rfc5444_writer_message *creator;
 };
 
@@ -206,31 +254,52 @@ struct rfc5444_writer_content_provider {
  * the rfc5444 writer
  */
 struct rfc5444_writer_target {
-  /* buffer for packet generation */
+  /*! buffer for packet generation */
   uint8_t *packet_buffer;
 
-  /* maximum number of bytes per packets allowed for target */
+  /*! maximum number of bytes per packets allowed for target */
   size_t packet_size;
 
-  /* callback for target specific packet handling */
-  void (*addPacketHeader)(struct rfc5444_writer *, struct rfc5444_writer_target *);
-  void (*finishPacketHeader)(struct rfc5444_writer *, struct rfc5444_writer_target *);
-  void (*sendPacket)(struct rfc5444_writer *, struct rfc5444_writer_target *, void *, size_t);
+  /**
+   * Callback to set RFC5444 packet header
+   * @param writer rfc5444 writer
+   * @param target rfc5444 target
+   */
+  void (*addPacketHeader)(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
 
-  /* internal handling for packet sequence numbers */
+  /**
+   * Callback to notify that all messages have been added and
+   * user can now modify the packet header again
+   * @param writer rfc5444 writer
+   * @param target rfc5444 target
+   */
+  void (*finishPacketHeader)(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
+
+  /**
+   * Callback to send a RFC5444 packet to a socket or destination
+   * @param writer rfc5444 writer
+   * @param target rfc5444 target
+   * @param ptr pointer to packet data
+   * @param len length of packet
+   */
+  void (*sendPacket)(struct rfc5444_writer *writer, struct rfc5444_writer_target *target, void *ptr, size_t len);
+
+  /*! true if packet should have a sequence number */
   bool _has_seqno;
+
+  /*! last used packet sequence number */
   uint16_t _seqno;
 
-  /* node for list of all targets*/
+  /*! node for list of all targets*/
   struct oonf_list_entity _target_node;
 
-  /* packet buffer is currently flushed */
+  /*! packet buffer is currently flushed */
   bool _is_flushed;
 
-  /* buffer for constructing the current packet */
+  /*! buffer for constructing the current packet */
   struct rfc5444_tlv_writer_data _pkt;
 
-  /* number of bytes used by messages */
+  /*! number of bytes used by messages */
   size_t _bin_msgs_size;
 };
 
@@ -239,63 +308,96 @@ struct rfc5444_writer_target {
  * be generated by the writer.
  */
 struct rfc5444_writer_message {
-  /* _target_node for tree of message creators */
+  /*! target node for tree of message creators */
   struct avl_node _msgcreator_node;
 
-  /* tree of message content providers */
+  /*! tree of message content providers */
   struct avl_tree _provider_tree;
 
-  /*
+  /**
    * true if the creator has already registered
    * false if the creator was registered because of a tlvtype or content
    * provider registration
    */
   bool _registered;
 
-  /* true if a different message must be generated for each target */
+  /*! true if a different message must be generated for each target */
   bool target_specific;
 
-  /* message type */
+  /*! message type */
   uint8_t type;
 
-  /* message address length */
-  uint8_t addr_len;
-
-  /* message hopcount */
+  /*! true if message should have a hopcount */
   bool has_hopcount;
+
+  /*! message hopcount */
   uint8_t hopcount;
 
-  /* message hoplimit */
+  /*! true if message should have a hoplimit */
   bool has_hoplimit;
+
+  /*! message hoplimit */
   uint8_t hoplimit;
 
-  /* message originator */
+  /*! true if message should have an originator */
   bool has_origaddr;
+
+  /*! message originator */
   uint8_t orig_addr[RFC5444_MAX_ADDRLEN];
 
-  /* message sequence number */
-  uint16_t seqno;
+  /*! true if message should have a sequence number */
   bool has_seqno;
 
-  /* head of writer_address list/tree */
+  /*! message sequence number */
+  uint16_t seqno;
+
+  /*! list of non-mandatory writer_addresses */
+  struct oonf_list_entity _non_mandatory_addr_head;
+
+  /*! list of all writer_addresses */
   struct oonf_list_entity _addr_head;
+
+  /*! tree of writer addresses */
   struct avl_tree _addr_tree;
 
-  /* head of message specific tlvtype list */
+  /*! head of message specific tlvtype list */
   struct oonf_list_entity _msgspecific_tlvtype_head;
 
-  /* callbacks for controling the message header fields */
-  void (*addMessageHeader)(struct rfc5444_writer *, struct rfc5444_writer_message *);
-  void (*finishMessageHeader)(struct rfc5444_writer *, struct rfc5444_writer_message *,
-      struct rfc5444_writer_address *, struct rfc5444_writer_address *, bool);
+  /**
+   * Callback to set message header
+   * @param writer rfc5444 writer
+   * @param msg rfc5444 message
+   * @return -1 if an error happened, 0 otherwise
+   */
+  int (*addMessageHeader)(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg);
 
-  /* callback to determine if a message shall be forwarded */
-  bool (*forward_target_selector)(struct rfc5444_writer_target *);
+  /**
+   * Callback to notify that all addresses have been written
+   * and user can now modify the message header.
+   * This is called once per message fragment
+   * @param writer rfc5444 writer
+   * @param msg rfc5444 message
+   * @param start first address of fragment
+   * @param end last address of fragment
+   * @param complete false if message has been fragmented,
+   *    true if message fit into MTU
+   */
+  void (*finishMessageHeader)(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
+    struct rfc5444_writer_address *first, struct rfc5444_writer_address *last, bool complete);
 
-  /* number of bytes necessary for addressblocks including tlvs */
+  /**
+   * callback to determine if a message shall be forwarded
+   * @param target rfc5444 target
+   * @param context rfc5444 message context
+   * @return true if message should be forwarded, false otherwise
+   */
+  bool (*forward_target_selector)(
+    struct rfc5444_writer_target *target, struct rfc5444_reader_tlvblock_context *context);
+
+  /*! number of bytes necessary for addressblocks including tlvs */
   size_t _bin_addr_size;
 
-  /* custom user data */
+  /*! custom user data */
   void *user;
 };
 
@@ -304,12 +406,102 @@ struct rfc5444_writer_message {
  * tlvs to a packet header.
  */
 struct rfc5444_writer_pkthandler {
-  /* _target_node for list of packet handlers */
+  /*! node for list of packet handlers */
   struct oonf_list_entity _pkthandle_node;
 
-  /* callbacks for packet handler */
-  void (*addPacketTLVs)(struct rfc5444_writer *, struct rfc5444_writer_target *);
-  void (*finishPacketTLVs)(struct rfc5444_writer *, struct rfc5444_writer_target *);
+  /**
+   * Callback to add packet TLVs to packet
+   * @param writer rfc5444 packet
+   * @param target rfc5444 target
+   */
+  void (*addPacketTLVs)(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
+
+  /**
+   * Callback to notify that all messages have been added and
+   * user can now set the earlier allocated packet TLVs.
+   * @param writer rfc5444 writer
+   * @param target rfc5444 target
+   */
+  void (*finishPacketTLVs)(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
+};
+
+/**
+ * a post-processor for rfc5444 messages/packets
+ */
+struct rfc5444_writer_postprocessor {
+  /*! node for treee of message post processors */
+  struct avl_node _node;
+
+  /*! order of message post-processors */
+  int32_t priority;
+
+  /*! number of bytes allocated for post-processor */
+  uint16_t allocate_space;
+
+  /**
+   * true if post-processing must be done per target,
+   * unused for packet post-processors
+   */
+  bool target_specific;
+
+  /**
+   * checks if post-processor applies to a message/packet
+   * @param processor this post-processor
+   * @param msg_type rfc5444 message type, -1 for packet signature
+   * @return true if signature applies to message type, false otherwise
+   */
+  bool (*is_matching_signature)(struct rfc5444_writer_postprocessor *processor, int msg_type);
+
+  /**
+   * Process binary data in post-processor
+   * @param processor rfc5444 post-processor
+   * @param target rfc5444 target
+   * @param msg rfc5444 message, NULL for packet signature
+   * @param data pointer to binary data
+   * @param length pointer to length of binary data, can be overwritten by function
+   * @return -1 if an error happened, 0 otherwise
+   */
+  int (*process)(struct rfc5444_writer_postprocessor *processor, struct rfc5444_writer_target *target,
+    struct rfc5444_writer_message *msg, uint8_t *data, size_t *length);
+};
+
+/**
+ * a post-processor for forwarded rfc5444 messages
+ */
+struct rfc5444_writer_forward_handler {
+  /*! node for treee of message post processors */
+  struct avl_node _node;
+
+  /*! order of message post-processors */
+  int32_t priority;
+
+  /*! number of bytes allocated for post-processor */
+  uint16_t allocate_space;
+
+  /**
+   * true if post-processing must be done per target,
+   */
+  bool target_specific;
+
+  /**
+   * checks if post-processor applies to a forwarded message
+   * @param handler this post-processor
+   * @param msg_type rfc5444 message type
+   * @return true if signature applies to message type, false otherwise
+   */
+  bool (*is_matching_signature)(struct rfc5444_writer_forward_handler *handler, uint8_t msg_type);
+
+  /**
+   * Process binary data in post-processor
+   * @param handler rfc5444 forwarding post-processor
+   * @param target rfc5444 target
+   * @param context RFC5444 message context
+   * @param data pointer to binary data
+   * @param length pointer to length of binary data, can be overwritten by function
+   * @return -1 if an error happened, 0 otherwise
+   */
+  int (*process)(struct rfc5444_writer_forward_handler *handler, struct rfc5444_writer_target *target,
+    struct rfc5444_reader_tlvblock_context *context, uint8_t *data, size_t *length);
 };
 
 /**
@@ -317,143 +509,182 @@ struct rfc5444_writer_pkthandler {
  * rfc5444 writer.
  */
 struct rfc5444_writer {
-  /* buffer for messages */
+  /*! buffer for messages */
   uint8_t *msg_buffer;
 
-  /* length of message buffer */
+  /*! address length of current message */
+  uint8_t msg_addr_len;
+
+  /*! length of message buffer */
   size_t msg_size;
 
-  /* buffer for addrtlv values of a message */
+  /*! buffer for addrtlv values of a message */
   uint8_t *addrtlv_buffer;
+
+  /*! length of addrtlv buffer */
   size_t addrtlv_size;
 
-  /* callbacks for memory management, NULL for calloc()/free() */
-  struct rfc5444_writer_address* (*malloc_address_entry)(void);
-  struct rfc5444_writer_addrtlv* (*malloc_addrtlv_entry)(void);
+  /**
+   * Callback to notify an instance that a message was put into a
+   * target buffer
+   * @param target pointer to rfc5444 target where
+   *   the message has been placed
+   */
+  void (*message_generation_notifier)(struct rfc5444_writer_target *target);
 
-  void (*free_address_entry)(void *);
-  void (*free_addrtlv_entry)(void *);
+  /**
+   * Callback to allocate a writer_address, NULL for use calloc()
+   * @return writer address, NULL if out of memory
+   */
+  struct rfc5444_writer_address *(*malloc_address_entry)(void);
 
-  /*
+  /**
+   * Callback to allocate an address tlv, NULL for use calloc()
+   * @return address tlv, NULL if out of memory
+   */
+  struct rfc5444_writer_addrtlv *(*malloc_addrtlv_entry)(void);
+
+  /**
+   * Callback to free a writer_address, NULL for use free()
+   * @param addr writer address
+   */
+  void (*free_address_entry)(struct rfc5444_writer_address *addr);
+
+  /**
+   * Callback to free a address tlv, NULL for use free()
+   * @param addrtlv address tlv
+   */
+  void (*free_addrtlv_entry)(struct rfc5444_writer_addrtlv *addrtlv);
+
+  /**
    * target of current generated message
    * only used for target specific message types
    */
   struct rfc5444_writer_target *msg_target;
 
-  /* tree of all message handlers */
+  /*! tree of all message handlers */
   struct avl_tree _msgcreators;
 
-  /* list of all packet handlers */
+  /*! list of all packet handlers */
   struct oonf_list_entity _pkthandlers;
 
-  /* list of all targets */
+  /*! tree of packet post-processors */
+  struct avl_tree _processors;
+
+  /*! tree of forwarding post-processors */
+  struct avl_tree _forwarding_processors;
+
+  /*! list of all targets */
   struct oonf_list_entity _targets;
 
-  /* list of generic tlvtypes */
+  /*! list of generic tlvtypes */
   struct oonf_list_entity _addr_tlvtype_head;
 
-  /* buffer for constructing the current message */
+  /*! buffer for constructing the current message */
   struct rfc5444_tlv_writer_data _msg;
 
-  /* number of bytes of addrtlv buffer currently used */
+  /*! number of bytes of addrtlv buffer currently used */
   size_t _addrtlv_used;
 
-  /* internal state of writer */
+  /*! internal state of writer */
   enum rfc5444_internal_state _state;
 };
 
 /* functions that can be called from addAddress callback */
-struct rfc5444_writer_address *rfc5444_writer_add_address(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, const struct netaddr *, bool mandatory);
-enum rfc5444_result rfc5444_writer_add_addrtlv(struct rfc5444_writer *writer,
-    struct rfc5444_writer_address *addr, struct rfc5444_writer_tlvtype *tlvtype,
-    const void *value, size_t length, bool allow_dup);
+EXPORT struct rfc5444_writer_address *rfc5444_writer_add_address(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, const struct netaddr *, bool mandatory);
+EXPORT enum rfc5444_result rfc5444_writer_add_addrtlv(struct rfc5444_writer *writer,
+  struct rfc5444_writer_address *addr, struct rfc5444_writer_tlvtype *tlvtype, const void *value, size_t length,
+  bool allow_dup);
 
 /* functions that can be called from add/finishMessageTLVs callback */
-enum rfc5444_result rfc5444_writer_add_messagetlv(struct rfc5444_writer *writer,
-    uint8_t type, uint8_t exttype, const void *value, size_t length);
-enum rfc5444_result rfc5444_writer_allocate_messagetlv(struct rfc5444_writer *writer,
-    bool has_exttype, size_t length);
-enum rfc5444_result rfc5444_writer_set_messagetlv(struct rfc5444_writer *writer,
-    uint8_t type, uint8_t exttype, const void *value, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_add_messagetlv(
+  struct rfc5444_writer *writer, uint8_t type, uint8_t exttype, const void *value, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_allocate_messagetlv(
+  struct rfc5444_writer *writer, bool has_exttype, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_set_messagetlv(
+  struct rfc5444_writer *writer, uint8_t type, uint8_t exttype, const void *value, size_t length);
 
 /* functions that can be called from add/finishMessageHeader callback */
-void rfc5444_writer_set_msg_addrlen(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, uint8_t addrlen);
-void rfc5444_writer_set_msg_header(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, bool has_originator,
-    bool has_hopcount, bool has_hoplimit, bool has_seqno);
-void rfc5444_writer_set_msg_originator(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, const void *originator);
-void rfc5444_writer_set_msg_hopcount(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, uint8_t hopcount);
-void rfc5444_writer_set_msg_hoplimit(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, uint8_t hoplimit);
-void rfc5444_writer_set_msg_seqno(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg, uint16_t seqno);
+EXPORT void rfc5444_writer_set_msg_header(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg,
+  bool has_originator, bool has_hopcount, bool has_hoplimit, bool has_seqno);
+EXPORT void rfc5444_writer_set_msg_originator(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, const void *originator);
+EXPORT void rfc5444_writer_set_msg_hopcount(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, uint8_t hopcount);
+EXPORT void rfc5444_writer_set_msg_hoplimit(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, uint8_t hoplimit);
+EXPORT void rfc5444_writer_set_msg_seqno(
+  struct rfc5444_writer *writer, struct rfc5444_writer_message *msg, uint16_t seqno);
 
 /* functions that can be called from add/finishPacketTLVs callback */
-enum rfc5444_result rfc5444_writer_add_packettlv(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target,
-    uint8_t type, uint8_t exttype, void *value, size_t length);
-enum rfc5444_result rfc5444_writer_allocate_packettlv(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target,
-    bool has_exttype, size_t length);
-enum rfc5444_result rfc5444_writer_set_packettlv(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target,
-    uint8_t type, uint8_t exttype, void *value, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_add_packettlv(struct rfc5444_writer *writer,
+  struct rfc5444_writer_target *target, uint8_t type, uint8_t exttype, void *value, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_allocate_packettlv(
+  struct rfc5444_writer *writer, struct rfc5444_writer_target *target, bool has_exttype, size_t length);
+EXPORT enum rfc5444_result rfc5444_writer_set_packettlv(struct rfc5444_writer *writer,
+  struct rfc5444_writer_target *target, uint8_t type, uint8_t exttype, void *value, size_t length);
 
 /* functions that can be called from add/finishPacketHeader */
-void rfc5444_writer_set_pkt_header(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target, bool has_seqno);
-void rfc5444_writer_set_pkt_seqno(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target, uint16_t seqno);
+EXPORT void rfc5444_writer_set_pkt_header(
+  struct rfc5444_writer *writer, struct rfc5444_writer_target *target, bool has_seqno);
+EXPORT void rfc5444_writer_set_pkt_seqno(
+  struct rfc5444_writer *writer, struct rfc5444_writer_target *target, uint16_t seqno);
 
 /* functions that can be called outside the callbacks */
-int rfc5444_writer_register_addrtlvtype(struct rfc5444_writer *writer,
-    struct rfc5444_writer_tlvtype *type, int msgtype);
-void rfc5444_writer_unregister_addrtlvtype(struct rfc5444_writer *writer,
-    struct rfc5444_writer_tlvtype *tlvtype);
+EXPORT int rfc5444_writer_register_addrtlvtype(
+  struct rfc5444_writer *writer, struct rfc5444_writer_tlvtype *type, int msgtype);
+EXPORT void rfc5444_writer_unregister_addrtlvtype(
+  struct rfc5444_writer *writer, struct rfc5444_writer_tlvtype *tlvtype);
 
-int rfc5444_writer_register_msgcontentprovider(
-    struct rfc5444_writer *writer, struct rfc5444_writer_content_provider *cpr,
-    struct rfc5444_writer_tlvtype *addrtlvs, size_t addrtlv_count);
-void rfc5444_writer_unregister_content_provider(
-    struct rfc5444_writer *writer, struct rfc5444_writer_content_provider *cpr,
-    struct rfc5444_writer_tlvtype *addrtlvs, size_t addrtlv_count);
+EXPORT int rfc5444_writer_register_msgcontentprovider(struct rfc5444_writer *writer,
+  struct rfc5444_writer_content_provider *cpr, struct rfc5444_writer_tlvtype *addrtlvs, size_t addrtlv_count);
+EXPORT void rfc5444_writer_unregister_content_provider(struct rfc5444_writer *writer,
+  struct rfc5444_writer_content_provider *cpr, struct rfc5444_writer_tlvtype *addrtlvs, size_t addrtlv_count);
 
-struct rfc5444_writer_message *rfc5444_writer_register_message(
-    struct rfc5444_writer *writer, uint8_t msgid, bool if_specific, uint8_t addr_len);
-void rfc5444_writer_unregister_message(struct rfc5444_writer *writer,
-    struct rfc5444_writer_message *msg);
+EXPORT void rfc5444_writer_register_postprocessor(
+  struct rfc5444_writer *writer, struct rfc5444_writer_postprocessor *processor);
+EXPORT void rfc5444_writer_unregister_postprocessor(
+  struct rfc5444_writer *, struct rfc5444_writer_postprocessor *processor);
 
-void rfc5444_writer_register_pkthandler(struct rfc5444_writer *writer,
-    struct rfc5444_writer_pkthandler *pkt);
-void rfc5444_writer_unregister_pkthandler(struct rfc5444_writer *writer,
-    struct rfc5444_writer_pkthandler *pkt);
+EXPORT void rfc5444_writer_register_forward_handler(
+  struct rfc5444_writer *writer, struct rfc5444_writer_forward_handler *processor);
+EXPORT void rfc5444_writer_unregister_forward_handler(
+  struct rfc5444_writer *, struct rfc5444_writer_forward_handler *processor);
 
-void rfc5444_writer_register_target(struct rfc5444_writer *writer,
-    struct rfc5444_writer_target *target);
-void rfc5444_writer_unregister_target(
-    struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
+EXPORT struct rfc5444_writer_message *rfc5444_writer_register_message(
+  struct rfc5444_writer *writer, uint8_t msgid, bool if_specific);
+EXPORT void rfc5444_writer_unregister_message(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg);
 
-/* prototype for message creation target filter */
-typedef bool (*rfc5444_writer_targetselector)(struct rfc5444_writer *, struct rfc5444_writer_target *, void *);
+EXPORT void rfc5444_writer_register_pkthandler(struct rfc5444_writer *writer, struct rfc5444_writer_pkthandler *pkt);
+EXPORT void rfc5444_writer_unregister_pkthandler(struct rfc5444_writer *writer, struct rfc5444_writer_pkthandler *pkt);
 
-bool rfc5444_writer_singletarget_selector(struct rfc5444_writer *, struct rfc5444_writer_target *, void *);
-bool rfc5444_writer_alltargets_selector(struct rfc5444_writer *, struct rfc5444_writer_target *, void *);
+EXPORT void rfc5444_writer_register_target(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
+EXPORT void rfc5444_writer_unregister_target(struct rfc5444_writer *writer, struct rfc5444_writer_target *target);
 
-enum rfc5444_result rfc5444_writer_create_message(
-    struct rfc5444_writer *writer, uint8_t msgid,
-    rfc5444_writer_targetselector useIf, void *param);
+/**
+ * prototype for message creation target filter
+ * @param writer rfc5444 writer
+ * @param target rfc5444 target
+ * @param custom custom data pointer
+ * @return true if target is selected
+ */
+typedef bool (*rfc5444_writer_targetselector)(
+  struct rfc5444_writer *writer, struct rfc5444_writer_target *target, void *custom);
 
-enum rfc5444_result rfc5444_writer_forward_msg(struct rfc5444_writer *writer,
-    uint8_t *msg, size_t len);
+EXPORT bool rfc5444_writer_singletarget_selector(struct rfc5444_writer *, struct rfc5444_writer_target *, void *);
+EXPORT bool rfc5444_writer_alltargets_selector(struct rfc5444_writer *, struct rfc5444_writer_target *, void *);
 
-void rfc5444_writer_flush(struct rfc5444_writer *, struct rfc5444_writer_target *, bool);
+EXPORT enum rfc5444_result rfc5444_writer_create_message(
+  struct rfc5444_writer *writer, uint8_t msgid, uint8_t addr_len, rfc5444_writer_targetselector useIf, void *param);
 
-void rfc5444_writer_init(struct rfc5444_writer *);
-void rfc5444_writer_cleanup(struct rfc5444_writer *writer);
+EXPORT enum rfc5444_result rfc5444_writer_forward_msg(
+  struct rfc5444_writer *writer, struct rfc5444_reader_tlvblock_context *context, const uint8_t *msg, size_t len);
+
+EXPORT void rfc5444_writer_flush(struct rfc5444_writer *, struct rfc5444_writer_target *, bool);
+
+EXPORT void rfc5444_writer_init(struct rfc5444_writer *);
+EXPORT void rfc5444_writer_cleanup(struct rfc5444_writer *writer);
 
 /* internal functions that are not exported to the user */
 void _rfc5444_writer_free_addresses(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg);
@@ -463,27 +694,28 @@ void _rfc5444_writer_begin_packet(struct rfc5444_writer *writer, struct rfc5444_
  * creates a message of a certain ID for a single target
  * @param writer pointer to writer context
  * @param msgid type of message
+ * @param addr_len length of address for this message
  * @param target pointer to outgoing target
  * @return RFC5444_OKAY if message was created and added to packet buffer,
  *   RFC5444_... otherwise
  */
-static inline enum rfc5444_result
+static INLINE enum rfc5444_result
 rfc5444_writer_create_message_singletarget(
-    struct rfc5444_writer *writer, uint8_t msgid, struct rfc5444_writer_target *target) {
-  return rfc5444_writer_create_message(writer, msgid, rfc5444_writer_singletarget_selector, target);
+  struct rfc5444_writer *writer, uint8_t msgid, uint8_t addr_len, struct rfc5444_writer_target *target) {
+  return rfc5444_writer_create_message(writer, msgid, addr_len, rfc5444_writer_singletarget_selector, target);
 }
 
 /**
  * creates a message of a certain ID for all target
  * @param writer pointer to writer context
  * @param msgid type of message
+ * @param addr_len length of address for this message
  * @return RFC5444_OKAY if message was created and added to packet buffer,
  *   RFC5444_... otherwise
  */
-static inline enum rfc5444_result
-rfc5444_writer_create_message_alltarget(
-    struct rfc5444_writer *writer, uint8_t msgid) {
-  return rfc5444_writer_create_message(writer, msgid, rfc5444_writer_alltargets_selector, NULL);
+static INLINE enum rfc5444_result
+rfc5444_writer_create_message_alltarget(struct rfc5444_writer *writer, uint8_t msgid, uint8_t addr_len) {
+  return rfc5444_writer_create_message(writer, msgid, addr_len, rfc5444_writer_alltargets_selector, NULL);
 }
 
 #endif /* RFC5444_WRITER_H_ */


### PR DESCRIPTION
This is a migration to OONF v0.15.1, this is an _experiment_ so don't merge it, this is to test (I haven't) and to see feedback.

I made this migration as some internals on `oonf_rfc5444` will be needed in order to have a proper RFC 5444 protocol implementation (a real one) that's more stable, and that can work on various network interfaces without problems, will ease the parsing of AODVv2 messages.