### PR TITLE
sys/net: refactor AODVv2 and RFC 5444

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,5 +26,9 @@ jobs:
               run: sudo apt-get install gcc g++ gcc-multilib g++-multilib build-essential make python3-pexpect
             - name: Building aodvv2_rcs
               run: make BOARD=native -C tests/aodvv2_rcs
-            - name: Test aodvv2_rcs
+            - name: Testing aodvv2_rcs
               run: make BOARD=native -C tests/aodvv2_rcs test
+            - name: Building rfc5444
+              run: make BOARD=native -C tests/rfc5444
+            - name: Testing rfc5444 
+              run: make BOARD=native -C tests/rfc5444 test

--- a/sys/Makefile.dep
+++ b/sys/Makefile.dep
@@ -16,6 +16,14 @@ ifneq (,$(filter vaina,$(USEMODULE)))
   USEMODULE += gnrc_sock_udp
 endif
 
+ifneq (,$(filter rfc5444,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6
+  USEMODULE += gnrc_udp
+  USEMODULE += manet
+  USEMODULE += oonf_rfc5444
+  USEMODULE += radio_firmware_net
+endif
+
 ifneq (,$(filter manet,$(USEMODULE)))
   USEMODULE += radio_firmware_net
 endif

--- a/sys/include/net/aodvv2/msg.h
+++ b/sys/include/net/aodvv2/msg.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_aodvv2
+ * @{
+ *
+ * @file
+ * @brief       AODVv2 Protocol Messages
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * @author      Gustavo Grisales <gustavosinbandera1@hotmail.com>
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef NET_AODVV2_MSG_H
+#define NET_AODVV2_MSG_H
+
+#include <stdint.h>
+
+#include "net/ipv6.h"
+#include "net/metric.h"
+#include "net/aodvv2/seqnum.h"
+#include "timex.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   AODVv2 message types
+ */
+typedef enum {
+    RFC5444_MSGTYPE_RREQ     = 10, /**< RREQ message type */
+    RFC5444_MSGTYPE_RREP     = 11, /**< RREP message type */
+    RFC5444_MSGTYPE_RERR     = 12, /**< RERR message type */
+    RFC5444_MSGTYPE_RREP_ACK = 13, /**< RREP_Ack message type */
+} rfc5444_msg_type_t;
+
+/**
+ * @brief   AODVv2 TLV types
+ */
+typedef enum {
+    RFC5444_MSGTLV_ORIGSEQNUM,
+    RFC5444_MSGTLV_TARGSEQNUM,
+    RFC5444_MSGTLV_UNREACHABLE_NODE_SEQNUM,
+    RFC5444_MSGTLV_METRIC,
+} rfc5444_tlv_type_t;
+
+/**
+ * @brief   Data about an OrigNode or TargNode.
+ */
+typedef struct {
+    ipv6_addr_t addr;             /**< IPv6 address of the node */
+    uint8_t pfx_len;              /**< IPv6 address length */
+    uint8_t metric;               /**< Metric value */
+    aodvv2_seqnum_t seqnum;       /**< Sequence Number */
+} node_data_t;
+
+/**
+ * @brief   All data contained in a RREQ or RREP.
+ */
+typedef struct {
+    uint8_t msg_hop_limit;        /**< Hop limit */
+    ipv6_addr_t sender;           /**< IP address of the neighboring router */
+    routing_metric_t metric_type; /**< Metric type */
+    node_data_t orig_node;        /**< OrigNode data */
+    node_data_t targ_node;        /**< TargNode data */
+    ipv6_addr_t seqnortr;         /**< SeqNoRtr */
+    timex_t timestamp;            /**< Time at which the message was received */
+} aodvv2_message_t;
+
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* AODVV2_MSG_H */
+/** @} */

--- a/sys/include/net/aodvv2/rfc5444.h
+++ b/sys/include/net/aodvv2/rfc5444.h
@@ -23,11 +23,8 @@
 #ifndef NET_AODVV2_RFC5444_H
 #define NET_AODVV2_RFC5444_H
 
-#include "net/aodvv2/seqnum.h"
+#include "net/aodvv2/msg.h"
 #include "net/manet.h"
-#include "net/metric.h"
-
-#include "timex.h"
 
 #include "common/netaddr.h"
 #include "rfc5444/rfc5444_reader.h"
@@ -71,49 +68,6 @@ extern "C" {
 #ifndef CONFIG_AODVV2_RFC5444_ADDR_TLVS_SIZE
 #define CONFIG_AODVV2_RFC5444_ADDR_TLVS_SIZE (1000)
 #endif
-
-/**
- * @brief   AODVv2 message types
- */
-typedef enum {
-    RFC5444_MSGTYPE_RREQ = 10,    /**< RREQ message type */
-    RFC5444_MSGTYPE_RREP = 11,    /**< RREP message type */
-    RFC5444_MSGTYPE_RERR = 12,    /**< RERR message type */
-    RFC5444_MSGTYPE_RREP_ACK = 13 /**< RREP_Ack message type */
-} rfc5444_msg_type_t;
-
-/**
- * @brief   AODVv2 TLV types
- */
-typedef enum {
-    RFC5444_MSGTLV_ORIGSEQNUM,
-    RFC5444_MSGTLV_TARGSEQNUM,
-    RFC5444_MSGTLV_UNREACHABLE_NODE_SEQNUM,
-    RFC5444_MSGTLV_METRIC,
-} rfc5444_tlv_type_t;
-
-/**
- * @brief   Data about an OrigNode or TargNode.
- */
-typedef struct {
-    ipv6_addr_t addr;             /**< IPv6 address of the node */
-    uint8_t pfx_len;              /**< IPv6 address length */
-    uint8_t metric;               /**< Metric value */
-    aodvv2_seqnum_t seqnum;       /**< Sequence Number */
-} node_data_t;
-
-/**
- * @brief   All data contained in a RREQ or RREP.
- */
-typedef struct {
-    uint8_t msg_hop_limit;        /**< Hop limit */
-    ipv6_addr_t sender;           /**< IP address of the neighboring router */
-    routing_metric_t metric_type; /**< Metric type */
-    node_data_t orig_node;        /**< OrigNode data */
-    node_data_t targ_node;        /**< TargNode data */
-    ipv6_addr_t seqnortr;         /**< SeqNoRtr */
-    timex_t timestamp;            /**< Time at which the message was received */
-} aodvv2_message_t;
 
 typedef struct {
     struct rfc5444_writer_target target; /**< RFC5444 writer target */

--- a/sys/include/net/rfc5444.h
+++ b/sys/include/net/rfc5444.h
@@ -1,0 +1,265 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net
+ * @{
+ *
+ * @file
+ * @brief       RFC 5444 server demultiplexer
+ *
+ * This is an implementation of the RFC 5444 protocol on top of the GNRC
+ * network stack.
+ *
+ * @see [RFC 5444]
+ *      (https://tools.ietf.org/html/rfc5444)
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * @author      Gustavo Grisales <gustavosinbandera1@hotmail.com>
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ */
+
+#ifndef NET_RFC5444_H
+#define NET_RFC5444_H
+
+#include "net/ipv6/addr.h"
+#include "net/gnrc/pktbuf.h"
+
+#include "common/netaddr.h"
+#include "rfc5444/rfc5444_writer.h"
+#include "rfc5444/rfc5444_reader.h"
+#include "rfc5444/rfc5444_iana.h"
+
+#include "thread.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   RFC 5444 thread stack size
+ */
+#ifndef CONFIG_RFC5444_STACK_SZIE
+#define CONFIG_RFC5444_STACK_SIZE (THREAD_STACKSIZE_DEFAULT)
+#endif
+
+/**
+ * @brief   RFC 5444 thread priority
+ */
+#ifndef CONFIG_RFC5444_PRIO
+#define CONFIG_RFC5444_PRIO (THREAD_PRIORITY_MAIN - 1)
+#endif
+
+/**
+ * @brief   RFC 5444 thread message queue size
+ */
+#ifndef CONFIG_RFC5444_MSG_QUEUE_SIZE
+#define CONFIG_RFC5444_MSG_QUEUE_SIZE (16)
+#endif
+
+/**
+ * @brief   Maximum message size
+ */
+#ifndef CONFIG_RFC5444_MSG_SIZE
+#define CONFIG_RFC5444_MSG_SIZE (64)
+#endif
+
+/**
+ * @brief   Maximum packet size
+ */
+#ifndef CONFIG_RFC5444_PACKET_SIZE
+#define CONFIG_RFC5444_PACKET_SIZE (128)
+#endif
+
+/**
+ * @brief   Address/TLVs buffer size
+ */
+#ifndef CONFIG_RFC5444_ADDR_TLVS_SIZE
+#define CONFIG_RFC5444_ADDR_TLVS_SIZE (1024)
+#endif
+
+/**
+ * @brief   Maximum available write targets
+ */
+#ifndef CONFIG_RFC5444_TARGET_NUMOF
+#define CONFIG_RFC5444_TARGET_NUMOF (16)
+#endif
+
+/**
+ * @brief   Message aggregationt time
+ *
+ * This is the time of aggregation after an RFC 5444 message has been created,
+ * if other messages for the same target are created within the aggregation,
+ * they will be sent in the same packet.
+ *
+ * Increasing this values increases the possibility of more messages fitting in
+ * one packet, although will slow down the time it takes to send a single
+ * packet.
+ */
+#ifndef CONFIG_RFC5444_AGGREGATION_TIME
+#define CONFIG_RFC5444_AGGREGATION_TIME (100)
+#endif
+
+/**
+ * @{
+ * @name IPC message types.
+ */
+#define GNRC_RFC5444_MSG_TYPE_AGGREGATE (0x9120) /**< RFC 5444 message aggregation */
+/** @} */
+
+/**
+ * @brief   Packet data.
+ */
+typedef struct {
+    ipv6_addr_t src; /**< Source IPv6 address */
+    uint16_t iface; /**< Network interface where this packet was received */
+    gnrc_pktsnip_t *pkt; /**< Pointer to packet */
+} gnrc_rfc5444_packet_data_t;
+
+/**
+ * @brief   Initialize GNRC RFC 5444 server/demultiplexer.
+ *
+ * @return 0 on success.
+ * @return less than 0 on failure.
+ */
+int gnrc_rfc5444_init(void);
+
+/**
+ * @brief   Acquire lock on the RFC 5444 reader.
+ *
+ * @note All read/writes when using the RFC 5444 reader MUST be locked.
+ *
+ * @note Holding a lock on the RFC 5444 reader prevents other threads for
+ *       registering message types. It also stops the main thread from
+ *       processing received packets.
+ *
+ * @see @ref gnrc_rfc5444_reader to get a pointer to the writer.
+ * @see @ref gnrc_rfc5444_reader_release to release the lock.
+ */
+void gnrc_rfc5444_reader_acquire(void);
+
+/**
+ * @brief   Release lock on the RFC 5444 reader.
+ */
+void gnrc_rfc5444_reader_release(void);
+
+/**
+ * @brief   Acquire lock on the RFC 5444 writer.
+ *
+ * @note All read/writes when using the RFC 5444 writer must be locked.
+ *
+ * @note Holding a lock on the writer blocks other threads that may want to
+ *       write messages.
+ *
+ * @see @ref gnrc_rfc5444_writer to get a pointer to the writer.
+ * @see @ref gnrc_rfc5444_writer_release to release the lock.
+ */
+void gnrc_rfc5444_writer_acquire(void);
+
+/**
+ * @brief   Release the lock on the RFC 5444 writer.
+ */
+void gnrc_rfc5444_writer_release(void);
+
+/**
+ * @brief   The RFC 5444 reader pointer
+ *
+ * @note You _MUST_ first [acquire the reader lock](@ref gnrc_rfc5444_reader_acquire).
+ */
+struct rfc5444_reader *gnrc_rfc5444_reader(void);
+
+/**
+ * @brief   The RFC 5444 writer pointer.
+ *
+ * @note You _MUST_ first [acquire the writer lock](@ref gnrc_rfc5444_writer_acquire).
+ */
+struct rfc5444_writer *gnrc_rfc5444_writer(void);
+
+/**
+ * @brief   Add a RFC 5444 writer target
+ *
+ * @note It's not necessary to unlock/lock the writer (it's locked internally).
+ *
+ * @see @ref gnrc_rfc5444_del_writer_target.
+ *
+ * @param[in]  dst   IPv6 link local destination address.
+ * @param[in]  iface Network interface.
+ *
+ * @return 0 if succeed.
+ * @return -ENOMEM on failed allocation of the target.
+ */
+int gnrc_rfc5444_add_writer_target(const ipv6_addr_t *dst, uint16_t iface);
+
+/**
+ * @brief   Delete a RFC 5444 writer target
+ *
+ * @note It's not necessary to unlock/lock the writer (it's locked internally).
+ *
+ * @see @ref gnrc_rfc5444_add_writer_target
+ *
+ * @param[in]  dst   IPv6 link local destination address.
+ * @param[in]  iface Network interface.
+ */
+void gnrc_rfc5444_del_writer_target(const ipv6_addr_t *dst, uint16_t iface);
+
+/**
+ * @brief   Get a RFC 5444 target pointer.
+ *
+ * @note The target MUST have been previously
+ *       [added](@ref gnrc_rfc5444_add_writer_target).
+ *
+ * @param[in]  dst   IPv6 link local destination address.
+ * @param[in]  iface Network interface.
+ *
+ * @return Pointer to target if found.
+ * @return NULL if target doesn't exists.
+ */
+struct rfc5444_writer_target *gnrc_rfc5444_get_writer_target(const ipv6_addr_t *dst, uint16_t iface);
+
+/**
+ * @brief   Get packet data
+ *
+ * Returns a pointer to the packet data, which contains information such as
+ * the source IPv6 address and the network interface where it was received.
+ *
+ * @note This MUST be only called inside RFC 5444 reader callbacks. Usage in
+ * other contexts is prone to undefined behaviour and it might ate your dog!
+ *
+ * @return Pointer to packet data.
+ */
+const gnrc_rfc5444_packet_data_t *gnrc_rfc5444_get_packet_data(void);
+
+/**
+ * @brief   `ipv6_addr_t` to `struct netaddr`.
+ *
+ * @pre (@p src != NULL) && (@p dst != NULL)
+ *
+ * @param[in]  src     Source.
+ * @param[in]  pfx_len Prefix length.
+ * @param[out] dst     Destination.
+ */
+void ipv6_addr_to_netaddr(const ipv6_addr_t *src, uint8_t pfx_len, struct netaddr *dst);
+
+/**
+ * @brief   `struct netaddr` to `ipv6_addr_t`.
+ *
+ * @pre (@p src != NULL) && (@p dst != NULL)
+ *
+ * @param[in]  src     Source.
+ * @param[out] dst     Destination.
+ * @param[out] pfx_len Prefix length.
+ */
+void netaddr_to_ipv6_addr(struct netaddr *src, ipv6_addr_t *dst, uint8_t *pfx_len);
+
+#ifdef __cpluslpus
+} /* extern "C" */
+#endif
+
+#endif /* NET_RFC5444_H */

--- a/sys/net/Kconfig
+++ b/sys/net/Kconfig
@@ -3,6 +3,7 @@
 menu "Network"
 
 rsource "aodvv2/Kconfig"
+rsource "rfc5444/Kconfig"
 rsource "vaina/Kconfig"
 
 endmenu

--- a/sys/net/Makefile
+++ b/sys/net/Makefile
@@ -6,6 +6,9 @@ endif
 ifneq (,$(filter manet,$(USEMODULE)))
   DIRS += manet
 endif
+ifneq (,$(filter rfc5444,$(USEMODULE)))
+  DIRS += rfc5444
+endif
 ifneq (,$(filter vaina,$(USEMODULE)))
   DIRS += vaina
 endif

--- a/sys/net/aodvv2/aodvv2.c
+++ b/sys/net/aodvv2/aodvv2.c
@@ -71,7 +71,7 @@ static gnrc_netreg_entry_t netreg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX
  * @brief   The RFC5444 packet reader context
  */
 static struct rfc5444_reader _reader;
-static mutex_t _reader_lock;
+static mutex_t _reader_lock = MUTEX_INIT;
 
 /**
  * @brief   The RFC5444 packet writer context
@@ -81,7 +81,7 @@ static aodvv2_writer_target_t _writer_context;
 static uint8_t _writer_msg_buffer[CONFIG_AODVV2_RFC5444_PACKET_SIZE];
 static uint8_t _writer_msg_addrtlvs[CONFIG_AODVV2_RFC5444_ADDR_TLVS_SIZE];
 static uint8_t _writer_pkt_buffer[CONFIG_AODVV2_RFC5444_PACKET_SIZE];
-static mutex_t _writer_lock;
+static mutex_t _writer_lock = MUTEX_INIT;
 
 static void _debug_packet(void *data, size_t size);
 
@@ -307,9 +307,6 @@ int aodvv2_init(gnrc_netif_t *netif)
     if (_pid != KERNEL_PID_UNDEF) {
         return _pid;
     }
-
-    mutex_init(&_writer_lock);
-    mutex_init(&_reader_lock);
 
     /* Start RFC5444 thread */
     _pid = thread_create(_stack, sizeof(_stack), CONFIG_AODVV2_RFC5444_PRIO,

--- a/sys/net/aodvv2/aodvv2_reader.c
+++ b/sys/net/aodvv2/aodvv2_reader.c
@@ -28,6 +28,7 @@
 #include "net/aodvv2/metric.h"
 #include "net/aodvv2/rcs.h"
 #include "net/aodvv2/rfc5444.h"
+#include "net/aodvv2/msg.h"
 #include "net/manet.h"
 
 #include "net/gnrc/ipv6/nib/ft.h"

--- a/sys/net/aodvv2/aodvv2_writer.c
+++ b/sys/net/aodvv2/aodvv2_writer.c
@@ -23,6 +23,7 @@
 
 #include "aodvv2_writer.h"
 #include "net/aodvv2/metric.h"
+#include "net/aodvv2/msg.h"
 
 #include "rfc5444_compat.h"
 

--- a/sys/net/rfc5444/Kconfig
+++ b/sys/net/rfc5444/Kconfig
@@ -1,0 +1,32 @@
+menuconfig KCONFIG_MODULE_RFC5444
+    bool "RFC 5444"
+    depends on MODULE_RFC5444
+
+if KCONFIG_MODULE_RFC5444
+
+config RFC5444_MSG_QUEUE_SIZE
+    int "Thread message queue size"
+    default 16
+    help
+        This is the message queue size for the RFC 5444 thread.
+
+config RFC5444_PACKET_SIZE
+    int "Packet maximum size"
+    default 128
+    help
+        This is the maximum size for a RFC 5444 packet.
+
+config RFC5444_ADDR_TLVS_SIZE
+    int "Address/TLVs buffer size"
+    default 1024
+    help
+        This is the buffer size for the RFC 5444 Address/TLVs buffer used by the
+        writer.
+
+config RFC5444_TARGET_NUMOF
+    int "Targets"
+    default 16
+    help
+        This is the maximum target count.
+
+endif

--- a/sys/net/rfc5444/Makefile
+++ b/sys/net/rfc5444/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/rfc5444/rfc5444.c
+++ b/sys/net/rfc5444/rfc5444.c
@@ -1,0 +1,514 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_aodvv2
+ * @{
+ *
+ * @file
+ * @brief       RFC5444 server implementation
+ *
+ * @author      Lotte Steenbrink <lotte.steenbrink@fu-berlin.de>
+ * @author      Gustavo Grisales <gustavosinbandera1@hotmail.com>
+ * @author      Jean Pierre Dudey <jeandudey@hotmail.com>
+ * @}
+ */
+
+#include <assert.h>
+
+#include "net/rfc5444.h"
+#include "net/manet.h"
+
+#include "net/gnrc/ipv6.h"
+#include "net/gnrc/udp.h"
+#include "net/gnrc/netif/hdr.h"
+
+#include "evtimer_msg.h"
+#include "rmutex.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+#include "rfc5444/rfc5444_print.h"
+#endif
+
+typedef struct {
+    struct rfc5444_writer_target target;
+    uint8_t pkt_buffer[CONFIG_RFC5444_PACKET_SIZE];
+    ipv6_addr_t dst;
+    uint16_t iface;
+    evtimer_msg_event_t aggregation_timeout;
+    bool used;
+} _gnrc_rfc5444_target_t;
+
+static kernel_pid_t _thread_pid = KERNEL_PID_UNDEF;
+
+#if ENABLE_DEBUG
+static char _thread_stack[CONFIG_RFC5444_STACK_SIZE + THREAD_EXTRA_STACKSIZE_PRINTF];
+#else
+static char _thread_stack[CONFIG_RFC5444_STACK_SIZE];
+#endif
+
+static struct rfc5444_reader _reader;
+static struct rfc5444_writer _writer;
+static rmutex_t _writer_lock = RMUTEX_INIT;
+static rmutex_t _reader_lock = RMUTEX_INIT;
+
+static uint8_t _writer_msg_buffer[CONFIG_RFC5444_MSG_SIZE];
+static uint8_t _writer_msg_addrtlvs[CONFIG_RFC5444_ADDR_TLVS_SIZE];
+
+static gnrc_rfc5444_packet_data_t _packet_data;
+
+static _gnrc_rfc5444_target_t _target[CONFIG_RFC5444_TARGET_NUMOF];
+
+static gnrc_netreg_entry_t netreg = GNRC_NETREG_ENTRY_INIT_PID(GNRC_NETREG_DEMUX_CTX_ALL,
+                                                               KERNEL_PID_UNDEF);
+
+static evtimer_msg_t _gnrc_rfc5444_evtimer;
+
+static char addr_str[IPV6_ADDR_MAX_STR_LEN];
+
+static void _message_generation_notifier(struct rfc5444_writer_target *target);
+static void *_thread(void *arg);
+static void _aggregate(struct rfc5444_writer_target *iface);
+static void _receive(gnrc_pktsnip_t *pkt);
+static void _send_packet(struct rfc5444_writer *writer,
+                         struct rfc5444_writer_target *iface, void *buffer,
+                         size_t length);
+static void _debug_packet(void *data, size_t size);
+
+int gnrc_rfc5444_init(void)
+{
+    if (_thread_pid > 0) {
+        DEBUG("gncr_rfc5444: trying to reinitialize\n");
+        return 0;
+    }
+
+    memset(&_target, 0, sizeof(_target));
+
+    evtimer_init_msg(&_gnrc_rfc5444_evtimer);
+
+    rfc5444_reader_init(&_reader);
+
+    _writer.msg_buffer = _writer_msg_buffer;
+    _writer.msg_size = sizeof(_writer_msg_buffer);
+    _writer.addrtlv_buffer = _writer_msg_addrtlvs;
+    _writer.addrtlv_size = sizeof(_writer_msg_addrtlvs);
+    _writer.message_generation_notifier = _message_generation_notifier;
+    rfc5444_writer_init(&_writer);
+
+    _thread_pid = thread_create(_thread_stack, sizeof(_thread_stack),
+                                CONFIG_RFC5444_PRIO, THREAD_CREATE_STACKTEST,
+                                _thread, NULL, "rfc5444");
+    if (_thread_pid < 0) {
+        DEBUG("gnrc_rfc5444: failed to create thread (errno = %d)\n",
+              _thread_pid);
+        return _thread_pid;
+    }
+
+    gnrc_netreg_entry_init_pid(&netreg, UDP_MANET_PORT, _thread_pid);
+    gnrc_netreg_register(GNRC_NETTYPE_UDP, &netreg);
+
+    return 0;
+}
+
+void gnrc_rfc5444_reader_acquire(void)
+{
+    rmutex_lock(&_reader_lock);
+}
+
+void gnrc_rfc5444_reader_release(void)
+{
+    rmutex_unlock(&_reader_lock);
+}
+
+void gnrc_rfc5444_writer_acquire(void)
+{
+    rmutex_lock(&_writer_lock);
+}
+
+void gnrc_rfc5444_writer_release(void)
+{
+    rmutex_unlock(&_writer_lock);
+}
+
+struct rfc5444_reader *gnrc_rfc5444_reader(void)
+{
+    return &_reader;
+}
+
+struct rfc5444_writer *gnrc_rfc5444_writer(void)
+{
+    return &_writer;
+}
+
+static inline bool _addr_equals(const ipv6_addr_t *addr,
+                                const _gnrc_rfc5444_target_t *tmp)
+{
+    return (addr == NULL) || ipv6_addr_is_unspecified(&tmp->dst) ||
+           ipv6_addr_equal(addr, &tmp->dst);
+}
+
+int gnrc_rfc5444_add_writer_target(const ipv6_addr_t *dst, uint16_t iface)
+{
+    DEBUG("gnrc_rfc5444: allocating target (dst = %s, iface = %d)\n",
+          (dst == NULL) ? "NULL" : ipv6_addr_to_str(addr_str, dst,
+                                                    sizeof(addr_str)), iface);
+
+    gnrc_rfc5444_reader_acquire();
+    _gnrc_rfc5444_target_t *target = NULL;
+    for (unsigned i = 0; i < ARRAY_SIZE(_target); i++) {
+        _gnrc_rfc5444_target_t *tmp = &_target[i];
+        if (tmp->iface == iface && _addr_equals(dst, tmp)) {
+            target = tmp;
+            break;
+        }
+        if (target == NULL && !tmp->used) {
+            target = tmp;
+        }
+    }
+
+    if (target == NULL) {
+        DEBUG("  couldn't allocate RFC 544 target\n");
+        gnrc_rfc5444_reader_release();
+        return -ENOMEM;
+    }
+
+    if (!target->used) {
+        memset(target->pkt_buffer, 0, CONFIG_RFC5444_PACKET_SIZE);
+
+        target->target.packet_buffer = target->pkt_buffer;
+        target->target.packet_size = CONFIG_RFC5444_PACKET_SIZE;
+        target->target.sendPacket = _send_packet;
+
+        rfc5444_writer_register_target(&_writer, &target->target);
+
+        memcpy(&target->dst, dst, sizeof(ipv6_addr_t));
+        target->iface = iface;
+
+        target->used = true;
+    }
+
+    gnrc_rfc5444_reader_release();
+    return 0;
+}
+
+void gnrc_rfc5444_del_writer_target(const ipv6_addr_t *dst, uint16_t iface)
+{
+    DEBUG("gnrc_rfc5444: deleting target (dst = %s, iface = %d)\n",
+          (dst == NULL) ? "NULL" : ipv6_addr_to_str(addr_str, dst,
+                                                    sizeof(addr_str)), iface);
+
+    gnrc_rfc5444_writer_acquire();
+    for (unsigned i = 0; i < ARRAY_SIZE(_target); i++) {
+        _gnrc_rfc5444_target_t *tmp = &_target[i];
+        if (tmp->iface == iface && _addr_equals(dst, tmp) && tmp->used) {
+            rfc5444_writer_unregister_target(&_writer, &tmp->target);
+            tmp->used = false;
+            break;
+        }
+    }
+    gnrc_rfc5444_writer_release();
+}
+
+struct rfc5444_writer_target *gnrc_rfc5444_get_writer_target(const ipv6_addr_t *dst, uint16_t iface)
+{
+    DEBUG("gnrc_rfc5444: searching target (dst = %s, iface = %d)\n",
+          (dst == NULL) ? "NULL" : ipv6_addr_to_str(addr_str, dst,
+                                                    sizeof(addr_str)), iface);
+
+    gnrc_rfc5444_writer_acquire();
+    _gnrc_rfc5444_target_t *target = NULL;
+    for (unsigned i = 0; i < ARRAY_SIZE(_target); i++) {
+        _gnrc_rfc5444_target_t *tmp = &_target[i];
+
+        if (tmp->used && _addr_equals(dst, tmp) && tmp->iface == iface) {
+            target = tmp;
+            break;
+        }
+    }
+
+#if ENABLE_DEBUG
+    if (target == NULL) {
+        DEBUG("  not found\n");
+    }
+#endif
+
+    gnrc_rfc5444_writer_release();
+    return (target == NULL) ? NULL : &target->target;
+}
+
+const gnrc_rfc5444_packet_data_t *gnrc_rfc5444_get_packet_data(void)
+{
+    return &_packet_data;
+}
+
+void ipv6_addr_to_netaddr(const ipv6_addr_t *src, uint8_t pfx_len,
+                          struct netaddr *dst)
+{
+    assert(src != NULL && dst != NULL);
+
+    /* Guard against invalid prefix lengths */
+    if (pfx_len > 128) {
+        pfx_len = 128;
+    }
+
+    dst->_type = AF_INET6;
+    dst->_prefix_len = pfx_len;
+
+    memcpy(dst->_addr, src, sizeof(dst->_addr));
+}
+
+void netaddr_to_ipv6_addr(struct netaddr *src, ipv6_addr_t *dst,
+                          uint8_t *pfx_len)
+{
+    assert(src != NULL && dst != NULL);
+
+    /* Address is unspecified */
+    if (src->_type == AF_UNSPEC) {
+        memset(dst, 0, sizeof(ipv6_addr_t));
+        *pfx_len = 0;
+        return;
+    }
+
+    /* Guard against invalid prefix lengths */
+    if (src->_prefix_len > 128) {
+        *pfx_len = 128;
+    }
+    else {
+        *pfx_len = src->_prefix_len;
+    }
+
+    /* Initialize dst with only the needed bits found in the prefix length */
+    ipv6_addr_t pfx;
+    memcpy(&pfx, src->_addr, sizeof(ipv6_addr_t));
+
+    ipv6_addr_init_prefix(dst, &pfx, *pfx_len);
+}
+
+static void _message_generation_notifier(struct rfc5444_writer_target *iface)
+{
+    _gnrc_rfc5444_target_t *target  = container_of(iface, _gnrc_rfc5444_target_t,
+                                                   target);
+
+    DEBUG("gnrc_rfc5444: message generated for target %p (dst = %s, iface = %d)\n",
+          (void *)target,
+          (target == NULL ) ? "NULL" : ipv6_addr_to_str(addr_str, &target->dst,
+                                                        sizeof(addr_str)),
+          (target == NULL) ? 0 : target->iface);
+
+    if (target == NULL) {
+        DEBUG("  invalid target\n");
+        return;
+    }
+
+    target->aggregation_timeout.event.next = NULL;
+    target->aggregation_timeout.event.offset = CONFIG_RFC5444_AGGREGATION_TIME;
+    target->aggregation_timeout.msg.type = GNRC_RFC5444_MSG_TYPE_AGGREGATE;
+    target->aggregation_timeout.msg.content.ptr = iface;
+
+    evtimer_add_msg(&_gnrc_rfc5444_evtimer,
+                    &target->aggregation_timeout, _thread_pid);
+}
+
+static void *_thread(void *arg)
+{
+    (void)arg;
+    msg_t msg;
+    msg_t reply;
+    msg_t msg_queue[CONFIG_RFC5444_MSG_QUEUE_SIZE];
+
+    /* Initialize message queue */
+    msg_init_queue(msg_queue, CONFIG_RFC5444_MSG_QUEUE_SIZE);
+
+    reply.content.value = (uint32_t)(-ENOTSUP);
+    reply.type = GNRC_NETAPI_MSG_TYPE_ACK;
+
+    while (1) {
+        msg_receive(&msg);
+
+        switch (msg.type) {
+            case GNRC_RFC5444_MSG_TYPE_AGGREGATE:
+                DEBUG("gnrc_rfc5444: GNRC_RFC5444_MSG_TYPE_AGGREGATE\n");
+                _aggregate((struct rfc5444_writer_target *)msg.content.ptr);
+                break;
+
+            case GNRC_NETAPI_MSG_TYPE_RCV:
+                DEBUG("gnrc_rfc5444: GNRC_NETAPI_MSG_TYPE_RCV\n");
+                _receive((gnrc_pktsnip_t *)msg.content.ptr);
+                break;
+
+            case GNRC_NETAPI_MSG_TYPE_GET:
+            case GNRC_NETAPI_MSG_TYPE_SET:
+                msg_reply(&msg, &reply);
+                break;
+
+            default:
+                DEBUG("gnrc_rfc5444: received unidentified message\n");
+                break;
+        }
+    }
+
+    /* Never reached */
+    return NULL;
+}
+
+static void _aggregate(struct rfc5444_writer_target *iface)
+{
+    _gnrc_rfc5444_target_t *target  = container_of(iface, _gnrc_rfc5444_target_t,
+                                                   target);
+
+    DEBUG("gnrc_rfc5444: aggregation of packets for target (dst = %s, iface = %d)\n",
+          ipv6_addr_to_str(addr_str, &target->dst, sizeof(addr_str)),
+          target->iface);
+
+    gnrc_rfc5444_writer_acquire();
+    rfc5444_writer_flush(&_writer, iface, false);
+    gnrc_rfc5444_writer_release();
+}
+
+static void _receive(gnrc_pktsnip_t *pkt)
+{
+    assert(pkt != NULL);
+    assert(pkt->data != NULL);
+
+    DEBUG("gnrc_rfc5444: received packet (pkt = %p)\n", (void *)pkt);
+
+    gnrc_rfc5444_reader_acquire();
+    memset(&_packet_data, 0, sizeof(gnrc_rfc5444_packet_data_t));
+
+    ipv6_hdr_t *ipv6_hdr = gnrc_ipv6_get_header(pkt);
+    gnrc_pktsnip_t *netif_hdr = gnrc_pktsnip_search_type(pkt,
+                                                         GNRC_NETTYPE_NETIF);
+
+    if (ipv6_hdr == NULL || netif_hdr == NULL) {
+        DEBUG("  invalid headers (ipv6 = %p, netif = %p)\n",
+              (void *)ipv6_hdr, (void *)netif_hdr);
+        gnrc_rfc5444_reader_release();
+        return;
+    }
+    gnrc_netif_t *iface = gnrc_netif_hdr_get_netif(netif_hdr->data);
+
+    memcpy(&_packet_data.src, &ipv6_hdr->src, sizeof(ipv6_addr_t));
+    _packet_data.iface = (iface == NULL) ? KERNEL_PID_UNDEF :
+                                           netif_get_id(&iface->netif);
+    _packet_data.pkt = pkt;
+
+    DEBUG("  src = %s, iface = %d\n",
+          ipv6_addr_to_str(addr_str, &_packet_data.src, sizeof(addr_str)),
+          _packet_data.iface);
+
+    _debug_packet(pkt->data, pkt->size);
+
+    /* Save packet data */
+    ipv6_addr_t sender;
+    assert(ipv6_hdr != NULL);
+    memcpy(&sender, &ipv6_hdr->src, sizeof(ipv6_addr_t));
+
+    if (rfc5444_reader_handle_packet(&_reader, pkt->data,
+                                     pkt->size) != RFC5444_OKAY) {
+        DEBUG("  couldn't handle packet\n");
+    }
+
+    gnrc_rfc5444_reader_release();
+    gnrc_pktbuf_release(pkt);
+}
+
+static void _send_packet(struct rfc5444_writer *writer,
+                         struct rfc5444_writer_target *iface, void *buffer,
+                         size_t length)
+{
+    (void)writer;
+
+    assert(iface != NULL);
+    assert(buffer != NULL);
+    assert(length != 0);
+
+    _gnrc_rfc5444_target_t *target  = container_of(iface, _gnrc_rfc5444_target_t,
+                                                   target);
+
+
+    DEBUG("gnrc_rfc5444: sending packet (dst = %s, iface = %d)\n",
+          ipv6_addr_to_str(addr_str, &target->dst, sizeof(addr_str)),
+          target->iface);
+    DEBUG("  length = %d, buffer = %p\n", length, (void *)buffer);
+
+    _debug_packet(buffer, length);
+
+    gnrc_pktsnip_t *payload;
+    gnrc_pktsnip_t *udp;
+    gnrc_pktsnip_t *ip;
+
+    /* Generate our pktsnip with our RFC5444 message */
+    payload = gnrc_pktbuf_add(NULL, buffer, length, GNRC_NETTYPE_UNDEF);
+    if (payload == NULL) {
+        DEBUG("gnrc_rfc5444: couldn't allocate payload\n");
+        return;
+    }
+
+    /* Build UDP packet */
+    uint16_t port = UDP_MANET_PORT;
+    udp = gnrc_udp_hdr_build(payload, port, port);
+    if (udp == NULL) {
+        DEBUG("gnrc_rfc5444: unable to allocate UDP header\n");
+        gnrc_pktbuf_release(payload);
+        return;
+    }
+
+    /* Build IPv6 header */
+    ip = gnrc_ipv6_hdr_build(udp, NULL, &target->dst);
+    if (ip == NULL) {
+        DEBUG("gnrc_rfc5444: unable to allocate IPv6 header\n");
+        gnrc_pktbuf_release(udp);
+        return;
+    }
+
+    /* Build netif header */
+    gnrc_netif_t *netif = gnrc_netif_get_by_pid(target->iface);
+    if (netif == NULL) {
+        DEBUG("gnrc_rfc5444: couldn't find interface %d\n", target->iface);
+        gnrc_pktbuf_release(ip);
+        return;
+    }
+
+    gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(NULL, 0, NULL, 0);
+    gnrc_netif_hdr_set_netif(netif_hdr->data, netif);
+    LL_PREPEND(ip, netif_hdr);
+
+    /* Send packet */
+    int res = gnrc_netapi_dispatch_send(GNRC_NETTYPE_UDP,
+                                        GNRC_NETREG_DEMUX_CTX_ALL, ip);
+    if (res < 1) {
+        DEBUG("gnrc_rfc5444: unable to locate UDP thread\n");
+        gnrc_pktbuf_release(ip);
+        return;
+    }
+}
+
+
+static void _debug_packet(void *data, size_t size)
+{
+#if ENABLE_DEBUG
+    static struct autobuf hexbuf;
+
+    /* Generate hexdump of packet */
+    abuf_hexdump(&hexbuf, "\t", data, size);
+    rfc5444_print_direct(&hexbuf, data, size);
+
+    /* Print hexdump to console */
+    DEBUG("%s", abuf_getptr(&hexbuf));
+
+    abuf_free(&hexbuf);
+#else
+    (void)data;
+    (void)size;
+#endif
+}

--- a/sys/oonf_api/common/autobuf.c
+++ b/sys/oonf_api/common/autobuf.c
@@ -58,7 +58,8 @@
 #include "common/autobuf.h"
 #include "common/string.h"
 
-#if defined(RIOT_VERSION) && !defined(BOARD_NATIVE)
+#if defined(RIOT_VERSION) && !defined(BOARD_NATIVE) && \
+    !(defined(MCU_ESP32) || defined(MCU_ESP8266))
 static size_t getpagesize(void)
 {
   return 512;

--- a/tests/rfc5444/Makefile
+++ b/tests/rfc5444/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+TESTS := "$(CURDIR)/tests/01-run.py"
+
+USEMODULE += embunit
+USEMODULE += rfc5444
+USEMODULE += netdev_eth
+USEMODULE += netdev_test
+USEMODULE += gnrc_netif
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/rfc5444/common.h
+++ b/tests/rfc5444/common.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    tests_gnrc_ipv6_nib Common header for GNRC's NIB tests
+ * @ingroup     tests
+ * @brief       Common definitions for GNRC's NIB tests
+ * @{
+ *
+ * @file
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <stdio.h>
+
+#include "net/gnrc.h"
+#include "net/gnrc/netif.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define _LL0            (0xce)
+#define _LL1            (0xab)
+#define _LL2            (0xfe)
+#define _LL3            (0xad)
+#define _LL4            (0xf7)
+#define _LL5            (0x26)
+
+extern gnrc_netif_t *_mock_netif;
+
+void _tests_init(void);
+int _mock_netif_get(gnrc_netapi_opt_t *opt);
+void _common_set_up(void);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COMMON_H */
+/** @} */

--- a/tests/rfc5444/main.c
+++ b/tests/rfc5444/main.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2020 Locha Inc
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test GNRC RFC 5444
+ *
+ * @author      Locha Mesh Developers <contact@locha.io>
+ *
+ * @}
+ */
+
+#include "embUnit.h"
+#include "embUnit/embUnit.h"
+
+#include "net/rfc5444.h"
+#include "net/ethernet.h"
+
+#include "common.h"
+
+#define TEST_ASSERT_EQUAL_ADDR(a, b) \
+    TEST_ASSERT(ipv6_addr_equal((a), (b)))
+
+#define RIOT_MSGTYPE_TEST 225
+
+static struct rfc5444_writer_message *_test_msg = NULL;
+
+static int _add_message_header(struct rfc5444_writer *writer, struct rfc5444_writer_message *msg)
+{
+    rfc5444_writer_set_msg_header(writer, msg, false, false, true, false);
+    rfc5444_writer_set_msg_hoplimit(writer, msg, 255);
+    return 0;
+}
+
+static void _set_up(void)
+{
+    _common_set_up();
+    gnrc_netif_acquire(_mock_netif);
+    _mock_netif->ipv6.mtu = ETHERNET_DATA_LEN;
+    _mock_netif->cur_hl = CONFIG_GNRC_NETIF_DEFAULT_HL;
+    gnrc_netif_release(_mock_netif);
+    gnrc_pktbuf_init();
+    /* remove messages */
+    while (msg_avail()) {
+        msg_t msg;
+        msg_receive(&msg);
+    }
+}
+
+static void test_gnrc_rfc5444_conv_roundtrip(void)
+{
+    ipv6_addr_t addr;
+    struct netaddr netaddr;
+    uint8_t pfx_len;
+
+    ipv6_addr_from_str(&addr, "fc00:db8::1");
+    pfx_len = 128;
+    ipv6_addr_to_netaddr(&addr, pfx_len, &netaddr);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&addr, &netaddr._addr, sizeof(ipv6_addr_t)));
+
+    addr = ipv6_addr_unspecified;
+    netaddr_to_ipv6_addr(&netaddr, &addr, &pfx_len);
+    TEST_ASSERT_EQUAL_INT(128, pfx_len);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(&addr, &netaddr._addr, sizeof(ipv6_addr_t)));
+}
+
+static void test_gnrc_rfcc5444_target_roundtrip(void)
+{
+    ipv6_addr_t dst;
+    ipv6_addr_from_str(&dst, "fe80::");
+
+    for (unsigned i = 0; i < CONFIG_RFC5444_TARGET_NUMOF; i++) {
+        dst.u8[15] = i;
+        TEST_ASSERT_EQUAL_INT(0, gnrc_rfc5444_add_writer_target(&dst, _mock_netif->pid));
+    }
+
+    /* we filled up the available targets, we can't add another this time */
+    dst.u8[15] = 16;
+    TEST_ASSERT_EQUAL_INT(-ENOMEM, gnrc_rfc5444_add_writer_target(&dst, _mock_netif->pid));
+
+    /* try to get the raw target interface for each one */
+    for (unsigned i = 0; i < CONFIG_RFC5444_TARGET_NUMOF; i++) {
+        dst.u8[15] = i;
+        TEST_ASSERT_NOT_NULL(gnrc_rfc5444_get_writer_target(&dst, _mock_netif->pid));
+    }
+
+    /* go ahead and delete each target we registered */
+    for (unsigned i = 0; i < CONFIG_RFC5444_TARGET_NUMOF; i++) {
+        dst.u8[15] = i;
+        gnrc_rfc5444_del_writer_target(&dst, _mock_netif->pid);
+    }
+
+    /* try again to get the raw target interface for each one, this time none
+     * should exist */
+    for (unsigned i = 0; i < CONFIG_RFC5444_TARGET_NUMOF; i++) {
+        dst.u8[15] = i;
+        TEST_ASSERT_NULL(gnrc_rfc5444_get_writer_target(&dst, _mock_netif->pid));
+    }
+}
+
+static void test_gnrc_rfc5444_send_message(void)
+{
+    msg_t msg;
+    gnrc_pktsnip_t *pkt;
+
+    ipv6_addr_t dst;
+    ipv6_addr_from_str(&dst, "fe80::1");
+
+    /* add out fake target */
+    TEST_ASSERT_EQUAL_INT(0, gnrc_rfc5444_add_writer_target(&dst, _mock_netif->pid));
+
+    gnrc_rfc5444_writer_acquire();
+
+    struct rfc5444_writer *writer = gnrc_rfc5444_writer();
+    TEST_ASSERT_MESSAGE(rfc5444_writer_create_message_alltarget(writer,
+                                                                RIOT_MSGTYPE_TEST,
+                                                                RFC5444_MAX_ADDRLEN) == RFC5444_OKAY,
+                        "oonf_rfc5444 output is bogus, check your available memory");
+    gnrc_rfc5444_writer_release();
+
+    msg_receive(&msg);
+    pkt = msg.content.ptr;
+
+    TEST_ASSERT_EQUAL_INT(GNRC_NETAPI_MSG_TYPE_SND, msg.type);
+    TEST_ASSERT_NOT_NULL(pkt->next);
+
+    gnrc_rfc5444_del_writer_target(&dst, _mock_netif->pid);
+}
+
+static Test *tests_gnrc_rfc5444(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_gnrc_rfc5444_conv_roundtrip),
+        new_TestFixture(test_gnrc_rfcc5444_target_roundtrip),
+        new_TestFixture(test_gnrc_rfc5444_send_message),
+    };
+
+    EMB_UNIT_TESTCALLER(tests, _set_up, NULL, fixtures);
+
+    return (Test *)&tests;
+}
+
+int main(void)
+{
+    _tests_init();
+    gnrc_rfc5444_init();
+
+    gnrc_rfc5444_writer_acquire();
+    struct rfc5444_writer *writer = gnrc_rfc5444_writer();
+    _test_msg = rfc5444_writer_register_message(writer, RIOT_MSGTYPE_TEST, false);
+    _test_msg->addMessageHeader = _add_message_header;
+    gnrc_rfc5444_writer_release();
+
+    TESTS_START();
+    TESTS_RUN(tests_gnrc_rfc5444());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/rfc5444/mockup_netif.c
+++ b/tests/rfc5444/mockup_netif.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "common.h"
+#include "msg.h"
+#include "net/gnrc.h"
+#include "net/ethernet.h"
+#include "net/gnrc/ipv6/nib.h"
+#include "net/gnrc/netif/ethernet.h"
+#include "net/gnrc/netif/internal.h"
+#include "net/netdev_test.h"
+#include "sched.h"
+#include "test_utils/expect.h"
+#include "thread.h"
+
+#define _MSG_QUEUE_SIZE  (2)
+
+gnrc_netif_t *_mock_netif = NULL;
+static gnrc_netif_t _netif;
+
+static netdev_test_t _mock_netdev;
+static char _mock_netif_stack[THREAD_STACKSIZE_DEFAULT];
+static msg_t _main_msg_queue[_MSG_QUEUE_SIZE];
+static gnrc_netreg_entry_t netreg_entry;
+
+void _common_set_up(void)
+{
+    expect(_mock_netif != NULL);
+    gnrc_ipv6_nib_init();
+    gnrc_netif_acquire(_mock_netif);
+    gnrc_ipv6_nib_init_iface(_mock_netif);
+    gnrc_netif_release(_mock_netif);
+    void *state = NULL;
+    gnrc_ipv6_nib_ft_t fte;
+    while (gnrc_ipv6_nib_ft_iter(NULL, 0, &state, &fte)) {
+        gnrc_ipv6_nib_ft_del(&fte.dst, fte.dst_len);
+    }
+}
+
+int _get_device_type(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    expect(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
+    return sizeof(uint16_t);
+}
+
+int _get_max_packet_size(netdev_t *dev, void *value, size_t max_len)
+{
+    (void)dev;
+    expect(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = ETHERNET_DATA_LEN;
+    return sizeof(uint16_t);
+}
+
+int _get_address(netdev_t *dev, void *value, size_t max_len)
+{
+    static const uint8_t addr[] = { _LL0, _LL1, _LL2, _LL3, _LL4, _LL5 };
+
+    (void)dev;
+    expect(max_len >= sizeof(addr));
+    memcpy(value, addr, sizeof(addr));
+    return sizeof(addr);
+}
+
+void _tests_init(void)
+{
+    msg_init_queue(_main_msg_queue, _MSG_QUEUE_SIZE);
+    gnrc_netreg_entry_init_pid(&netreg_entry, GNRC_NETREG_DEMUX_CTX_ALL,
+                               sched_active_pid);
+    gnrc_netreg_register(GNRC_NETTYPE_UDP, &netreg_entry);
+    netdev_test_setup(&_mock_netdev, 0);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_DEVICE_TYPE,
+                           _get_device_type);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_MAX_PDU_SIZE,
+                           _get_max_packet_size);
+    netdev_test_set_get_cb(&_mock_netdev, NETOPT_ADDRESS,
+                           _get_address);
+    int res = gnrc_netif_ethernet_create(&_netif,
+           _mock_netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
+            "mockup_eth", &_mock_netdev.netdev
+        );
+    _mock_netif = &_netif;
+    expect(res == 0);
+    /* we do not want to test for SLAAC here so just assure the configured
+     * address is valid */
+    expect(!ipv6_addr_is_unspecified(&_mock_netif->ipv6.addrs[0]));
+    _mock_netif->ipv6.addrs_flags[0] &= ~GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK;
+    _mock_netif->ipv6.addrs_flags[0] |= GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID;
+}
+
+/** @} */

--- a/tests/rfc5444/tests/01-run.py
+++ b/tests/rfc5444/tests/01-run.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run_check_unittests
+
+
+if __name__ == "__main__":
+    sys.exit(run_check_unittests())


### PR DESCRIPTION
**Description**

- Adds separate RFC 5444 module that can be used without AODVv2 (easier testing, less surprises).
- Adds a test for the new module.
- Compiles and tests on the GitHub Workflow.

This can be tested on `native`, `Turpial` or `cc1312-launchpad` and any micro controller with sufficient RAM.

Also works on the ESP32 :wink: if we someday are going to use the powerful ESP-NOW interface which is pretty fast (in terms of Mbps) alongside the IEEE 802.15.4g interface. And yep, this RFC 5444 implementation allows the usage of multiple interfaces at the same time so it's not that distant to use an ESP32 or ESP8266 for these purposes.

**Tesing**

- `make BOARD=native -C tests/rfc5444`
- `make BOARD=native -C tests/rfc5444 test`